### PR TITLE
Document flake usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # clojure-nix-locker
+
 Simple and flexible tool to build clojure projects with Nix.
 
 ## Usage
 
 The [example/](example) directory has a small clojure program and the nix code required to build it.
+
+### Stable non-flake way
 
 To generate/update the lockfile:
 ```sh
@@ -14,6 +17,16 @@ To build:
 ```sh
 nix-build -A uberjar
 ```
+
+### With flakes
+
+You can generate a flake example with:
+
+```sh
+mkdir play-with-clojure-nix-locker && cd play-with-clojure-nix-locker && nix flake init -t github:bevuta/clojure-nix-locker
+```
+
+The [example README](example/README.md) has some next steps.
 
 ## Why another tool?
 
@@ -35,6 +48,7 @@ This approach results in a pretty simple implementation and loose coupling to th
 As a consequence, things like aliases "just work" without requiring `clojure-nix-locker` to know about them.
 
 Of course, this has its downsides too:
+
 - If the directory layout of these caches changes, this tool breaks.
 - Whatever classpath(s) your clojure tools compute at build-time will only work for the duration of that build.
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,29 @@
+# Generating the lockfile
+
+To generate the lockfile of all the deps:
+
+```sh
+nix run .#locker
+```
+
+Run this after modifying `deps.edn`.
+
+# Building uberjar using the lockfile classpath
+
+```sh
+nix build .#uberjar
+```
+
+Run uberjar:
+
+```sh
+./result/bin/simple
+```
+
+# Starting a devshell with the locked classpath
+
+```
+nix develop
+```
+
+It will print out the current locked classpath.

--- a/example/flake.lock
+++ b/example/flake.lock
@@ -2,15 +2,19 @@
   "nodes": {
     "clojure-nix-locker": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1661772283,
-        "narHash": "sha256-LmGRMjE2f6bbt3ePtyZw4NfYMX9uFCqhvttOpw+Drhk=",
+        "lastModified": 1690395402,
+        "narHash": "sha256-CgbSNEzZwputkS6HpZbBe8uaBTjttlpPNvDqJrw0Foc=",
         "owner": "bevuta",
         "repo": "clojure-nix-locker",
-        "rev": "0231d4258220178ef7f34648f3dfedbe2135bb17",
+        "rev": "e2b0e4b043197b8d63e39c37333054689427a997",
         "type": "github"
       },
       "original": {
@@ -20,27 +24,15 @@
       }
     },
     "flake-utils": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
+      "inputs": {
+        "systems": "systems"
       },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -51,26 +43,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661772043,
-        "narHash": "sha256-J02+gLWJXFYKnA5XRPd/5M+Lj6ayfbxSG/yYh0ghHxE=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "0c1c5b34f9604237450a2ece38c2e9168fa088b3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1661353537,
-        "narHash": "sha256-1E2IGPajOsrkR49mM5h55OtYnU0dGyre6gl60NXKITE=",
+        "lastModified": 1709356872,
+        "narHash": "sha256-mvxCirJbtkP0cZ6ABdwcgTk0u3bgLoIoEFIoYBvD6+4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0e304ff0d9db453a4b230e9386418fd974d5804a",
+        "rev": "458b097d81f90275b3fdf03796f0563844926708",
         "type": "github"
       },
       "original": {
@@ -81,8 +58,23 @@
     "root": {
       "inputs": {
         "clojure-nix-locker": "clojure-nix-locker",
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -54,6 +54,21 @@
           drv = my-clojure-nix-locker.locker;
         };
         devShells.default = pkgs.mkShell {
+          shellHook = ''
+            # Trace all Bash executions
+            set -o xtrace
+
+            source ${my-clojure-nix-locker.shellEnv}
+
+            echo "Current locked classpath:"
+            ${pkgs.clojure}/bin/clojure -Spath
+
+            set +o xtrace
+
+            echo
+            echo "Note that \$HOME is overridden and read-only: $HOME"
+            echo
+          '';
           inputsFrom = [
             packages.uberjar
           ];
@@ -63,6 +78,9 @@
             clojure
             clj-kondo
             coreutils
+            # This provides the standalone `clojure-nix-locker` script in the shell
+            # You can use it, or `nix run .#locker`
+            # Both does the same
             my-clojure-nix-locker.locker
           ];
         };

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -3,8 +3,11 @@
 
   inputs = {
     nixpkgs.url = "nixpkgs";
-    clojure-nix-locker.url = "github:bevuta/clojure-nix-locker";
     flake-utils.url = "github:numtide/flake-utils";
+
+    clojure-nix-locker.url = "github:bevuta/clojure-nix-locker";
+    clojure-nix-locker.inputs.nixpkgs.follows = "nixpkgs";
+    clojure-nix-locker.inputs.flake-utils.follows = "flake-utils";
   };
 
   outputs = { self, nixpkgs, flake-utils, clojure-nix-locker, ... }:


### PR DESCRIPTION
This PR does not affect any functionality. #11 builds on top of it, and does add new functionality.

It documents how to `flake init` the example, and then shows how to use that example.

It also explains how `clojure-nix-locker` and `nix run .#locker` has the same result.