### PR TITLE
Still isolated with writeable home

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can generate a flake example with:
 mkdir play-with-clojure-nix-locker && cd play-with-clojure-nix-locker && nix flake init -t github:bevuta/clojure-nix-locker
 ```
 
-The [example README](example/README.md) has some next steps.
+The [example README](example/README.md) has some next steps and further documentation.
 
 ## Why another tool?
 

--- a/default.nix
+++ b/default.nix
@@ -61,6 +61,9 @@ in {
           chmod -R +w .
 
           # Ensures that clojure creates all the caches in our empty separate home directory
+          # We cannot use CLJ_JVM_OPTS here, because we want to override where `clojure`
+          # resolves _itself_ from as well as the classpath that it builds
+          # https://clojure.org/reference/clojure_cli#env_vars
           export JAVA_TOOL_OPTIONS="-Duser.home=$tmp/home"
 
           ${command}

--- a/example/README.md
+++ b/example/README.md
@@ -27,3 +27,31 @@ nix develop
 ```
 
 It will print out the current locked classpath.
+
+# Two ways to get a locked classpath
+
+## Sourcing `shellEnv`
+
+During a `buildPhase` you can source the locked `shellEnv` like this:
+
+```sh
+source ${my-clojure-nix-locker.shellEnv}
+```
+
+This overrides `$JAVA_TOOL_OPTIONS` and `$HOME` to the locked classpath. Great for building, not great for devShells.
+
+## Using `lockedClojure`
+
+`lockedClojure` wraps `pkgs.clojure`, overriding `$JAVA_TOOL_OPTIONS` and `$HOME` only on `clojure` or `clj` invocation. Great for devShells.
+
+If `pkgs.clojure` is anywhere in the set of inputs for a devShell, it may override the `lockedClojure`. Check with:
+
+```sh
+clojure -Spath
+```
+
+You should see a classpath with references to `/nix/store`.
+
+# Overriding other programs that are aware of classpaths
+
+`wrapPrograms` is available to wrap other programs into the locked classpath. `wrapClojure` is also available if you want to wrap a custom `pkgs.clojure`.

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,13 @@
           locker = locked.commandLocker command;
           homeDirectory = locked.homeDirectory;
           shellEnv = locked.shellEnv;
+          # Function to wrap your own overridden pkgs.clojure into a locked environment, a special case
+          wrapClojure = locked.wrapClojure;
+          # Provide an already locked clojure
+          # You want to ensure that pkgs.clojure are not reference anywhere else
+          lockedClojure = locked.wrapClojure pkgs.clojure;
+          # Function to wrap other Java classpath aware programs with the locked environment
+          wrapPrograms = locked.wrapPrograms;
         };
     };
 


### PR DESCRIPTION
This PR adds new functionality, and builds on top of #10.

`shellEnv` overrides `$JAVA_TOOL_OPTIONS` and `$HOME` to the locked classpath. Great for building, not great for devShells.

`lockedClojure` is exported from `customLocker` which allows `clojure` and `clj` to be locked in the shell, and `$HOME` to remain writeable.

The example has been updated accordingly, as well as the example README.

Also added a comment on why `CLJ_JVM_OPTS` is insufficient for `clojure-nix-locker`.