### PR TITLE
Add extraPrepInputs option

### DIFF
--- a/createHome.nix
+++ b/createHome.nix
@@ -2,7 +2,7 @@
 # (for maven dependencies) and ~/.gitlibs (for git dependencies) according
 # to a lockfile generated with ./locker.py
 
-{ pkgs, src, mavenRepos, lockfile }:
+{ pkgs, src, mavenRepos, lockfile, extraPrepInputs }:
 let
   lib = pkgs.lib;
   # Fall back to no dependencies if the lockfile hasn't been generated yet
@@ -87,7 +87,7 @@ let
     if spec ? prep then
       let prep = spec.prep; in
       pkgs.runCommand "${name}-prepped"
-        { nativeBuildInputs = [ (utils.wrapClojure unpreppedHome pkgs.clojure) ]; }
+        { nativeBuildInputs = [ (utils.wrapClojure unpreppedHome pkgs.clojure) ] ++ extraPrepInputs; }
         ''
           cp -r ${path} $out
           chmod -R +w $out

--- a/createHome.nix
+++ b/createHome.nix
@@ -92,7 +92,7 @@ let
           cp -r ${path} $out
           chmod -R +w $out
           cd $out
-          clojure -X:${prep.alias} ${prep.fn}
+          clojure -J-Dclojure.main.report=stderr -X:${prep.alias} ${prep.fn}
         ''
     else
       path;

--- a/default.nix
+++ b/default.nix
@@ -26,6 +26,8 @@ in {
         "https://repo1.maven.org/maven2/"
         "https://repo.clojars.org/"
       ]
+    , # Extra inputs for the dependency "prep" phase
+      extraPrepInputs ? [ ]
     }: rec {
       commandLocker = command: pkgs.writeShellApplication {
         name = "clojure-nix-locker";
@@ -71,7 +73,7 @@ in {
         '';
       };
       homeDirectory = import ./createHome.nix {
-        inherit pkgs src lockfile mavenRepos;
+        inherit pkgs src lockfile mavenRepos extraPrepInputs;
       };
       shellEnv = utils.shellEnv homeDirectory;
       wrapClojure = utils.wrapClojure homeDirectory;


### PR DESCRIPTION
This allows passing in extra inputs to be added to the environment of the dependency "prep" phase.

Piggy-backed is a patch for making the "prep" phase output exceptions to stderr (by default, they would be stored in a file which would become inaccessible when the overall nix build fails).