### PR TITLE
Add support for Maven dependencies with version ranges

### DIFF
--- a/createHome.nix
+++ b/createHome.nix
@@ -13,12 +13,14 @@ let
     then lib.importJSON (src + "/${lockfile}")
     else { maven = {}; git = {}; };
 
-  fetchMaven = file: sha256: {
-    name = file;
+  fetchMaven = file: dep: {
+    name = if dep ? name
+           then "${builtins.dirOf file}/${dep.name}"
+           else file;
     path = pkgs.fetchurl {
       # Try to fetch this maven dependency from all given maven repositories
       urls = map (repo: repo + file) mavenRepos;
-      inherit sha256;
+      inherit (dep) sha256;
     };
   };
 

--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,10 @@ let
 
   standaloneLocker = pkgs.writers.writePython3Bin "standalone-clojure-nix-locker" {
     libraries = [ pkgs.python3Packages.GitPython ];
-    # We don't care about lines being too long
-    flakeIgnore = [ "E501" ];
+    flakeIgnore = [
+      "E501" # We don't care about lines being too long
+      "W504" # Allow line breaks after binary operators for multi-line conditionals
+    ];
   } ./locker.py;
 
   utils = import ./utils.nix { inherit pkgs; };

--- a/example/deps.lock.json
+++ b/example/deps.lock.json
@@ -8,206 +8,611 @@
     }
   },
   "maven": {
-    "aopalliance/aopalliance/1.0/aopalliance-1.0.jar": "0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08",
-    "aopalliance/aopalliance/1.0/aopalliance-1.0.pom": "26e82330157d6b844b67a8064945e206581e772977183e3e31fec6058aa9a59b",
-    "com/cognitect/aws/api/0.8.539/api-0.8.539.jar": "614e67f769bb0c6480e793557ea4e0d2365727ce809ed814ecf99501b9db5da9",
-    "com/cognitect/aws/api/0.8.539/api-0.8.539.pom": "5df71fed2040cbad327fe02d542b51e1945f446bc42d3a1afbaa77f13cdd89d4",
-    "com/cognitect/aws/endpoints/1.1.12.150/endpoints-1.1.12.150.jar": "a98fe61774d25891e199fc6d6b8ea405c3b08de220bdff0926afed21b789944f",
-    "com/cognitect/aws/endpoints/1.1.12.150/endpoints-1.1.12.150.pom": "deffd3470cc04d158b9f6aa9d617142e6874ba6a112b4fbec6e036c976cc76d3",
-    "com/cognitect/aws/s3/814.2.1053.0/s3-814.2.1053.0.jar": "ab1ec40e9c7268bd69e08d8111a845cf68ab7083b4c15e78a573b29e52290caf",
-    "com/cognitect/aws/s3/814.2.1053.0/s3-814.2.1053.0.pom": "04c48d8847fa6beaf7e9423355fc15364d1de73fbe4aee90435924fcf0f49788",
-    "com/cognitect/http-client/1.0.110/http-client-1.0.110.jar": "9be8bdef307b4a1e44302a3346911a139a5e5db8507cb51bf7c41df96623192d",
-    "com/cognitect/http-client/1.0.110/http-client-1.0.110.pom": "42dec0f6a0dfe3bf7b0c296c1d0106dd25dcc784e922ab532042b3f1869e380e",
-    "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
-    "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.pom": "19889dbdf1b254b2601a5ee645b8147a974644882297684c798afe5d63d78dfe",
-    "com/google/errorprone/error_prone_annotations/2.7.1/error_prone_annotations-2.7.1.jar": "cd5257c08a246cf8628817ae71cb822be192ef91f6881ca4a3fcff4f1de1cff3",
-    "com/google/errorprone/error_prone_annotations/2.7.1/error_prone_annotations-2.7.1.pom": "31a872e1149c5f3a8bc05fb4de455e5ea608ecfad1af222cb7637ca6c762ee25",
-    "com/google/errorprone/error_prone_parent/2.7.1/error_prone_parent-2.7.1.pom": "0a6e242e28104e8093405ae37969660a438b71c4c1b73fc4ff716db89da88de6",
-    "com/google/google/5/google-5.pom": "e09d345e73ca3fbca7f3e05f30deb74e9d39dd6b79a93fee8c511f23417b6828",
-    "com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar": "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26",
-    "com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.pom": "e96042ce78fecba0da2be964522947c87b40a291b5fd3cd672a434924103c4b9",
-    "com/google/guava/guava-parent/26.0-android/guava-parent-26.0-android.pom": "f8698ab46ca996ce889c1afc8ca4f25eb8ac6b034dc898d4583742360016cc04",
-    "com/google/guava/guava-parent/31.0.1-android/guava-parent-31.0.1-android.pom": "30a51d34b075c9b4eb6a2da3fba6c1f5047b45225a3a03aebcefc0b7880e5735",
-    "com/google/guava/guava/31.0.1-android/guava-31.0.1-android.jar": "9425a423a4cb9d9db0356300722d9bd8e634cf539f29d97bb84f457cccd16eb8",
-    "com/google/guava/guava/31.0.1-android/guava-31.0.1-android.pom": "13d4e2998aac652fc6d7b9eaf3e495fa2952bf98ef68a2c49aa5eaa0bbe731a9",
-    "com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar": "b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99",
-    "com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom": "18d4b1db26153d4e55079ce1f76bb1fe05cdb862ef9954a88cbcc4ff38b8679b",
-    "com/google/inject/guice-parent/4.2.2/guice-parent-4.2.2.pom": "5a74ba3d22be1ac13b9e782f13a7d957db2a24ded359481394c9e889f1c037d6",
-    "com/google/inject/guice/4.2.2/guice-4.2.2-no_aop.jar": "0f4f5fb28609a4d2b38b7f7128be7cf9b541f25283d71b4e56066d99683aafff",
-    "com/google/inject/guice/4.2.2/guice-4.2.2.pom": "06f3c3ddad57b30bfe88655456a04731e56a78ad0dd909e65c71881003b96479",
-    "com/google/j2objc/j2objc-annotations/1.3/j2objc-annotations-1.3.jar": "21af30c92267bd6122c0e0b4d20cccb6641a37eaf956c6540ec471d584e64a7b",
-    "com/google/j2objc/j2objc-annotations/1.3/j2objc-annotations-1.3.pom": "5faca824ba115bee458730337dfdb2fcea46ba2fd774d4304edbf30fa6a3f055",
-    "commons-codec/commons-codec/1.11/commons-codec-1.11.jar": "e599d5318e97aa48f42136a2927e6dfa4e8881dff0e6c8e3109ddbbff51d7b7d",
-    "commons-codec/commons-codec/1.11/commons-codec-1.11.pom": "c1e7140d1dea8fdf3528bc1e3c5444ac0b541297311f45f9806c213ec3ee9a10",
-    "commons-io/commons-io/2.11.0/commons-io-2.11.0.jar": "961b2f6d87dbacc5d54abf45ab7a6e2495f89b75598962d8c723cea9bc210908",
-    "commons-io/commons-io/2.11.0/commons-io-2.11.0.pom": "2e016fd7e3244b5f2c20acad834d93aa4790486ee1e4564641361a3e831eef59",
-    "commons-logging/commons-logging/1.2/commons-logging-1.2.jar": "daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636",
-    "commons-logging/commons-logging/1.2/commons-logging-1.2.pom": "c91ab5aa570d86f6fd07cc158ec6bc2c50080402972ee9179fe24100739fbb20",
-    "javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2.jar": "5909b396ca3a2be10d0eea32c74ef78d816e1b4ead21de1d78de1f890d033e04",
-    "javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2.pom": "52d73f35f7e638ce3cb56546f879c20e7f7019f72aa20cde1fa80e97865dfd40",
-    "javax/inject/javax.inject/1/javax.inject-1.jar": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-    "javax/inject/javax.inject/1/javax.inject-1.pom": "943e12b100627804638fa285805a0ab788a680266531e650921ebfe4621a8bfa",
-    "net/java/jvnet-parent/3/jvnet-parent-3.pom": "30f5789efa39ddbf96095aada3fc1260c4561faf2f714686717cb2dc5049475a",
-    "org/apache/apache/13/apache-13.pom": "ff513db0361fd41237bef4784968bc15aae478d4ec0a9496f811072ccaf3841d",
-    "org/apache/apache/18/apache-18.pom": "7831307285fd475bbc36b20ae38e7882f11c3153b1d5930f852d44eda8f33c17",
-    "org/apache/apache/19/apache-19.pom": "91f7a33096ea69bac2cbaf6d01feb934cac002c48d8c8cfa9c240b40f1ec21df",
-    "org/apache/apache/21/apache-21.pom": "af10c108da014f17cafac7b52b2b4b5a3a1c18265fa2af97a325d9143537b380",
-    "org/apache/apache/23/apache-23.pom": "bc10624e0623f36577fac5639ca2936d3240ed152fb6d8d533ab4d270543491c",
-    "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar": "dac807f65b07698ff39b1b07bfef3d87ae3fd46d91bbf8a2bc02b2a831616f68",
-    "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.pom": "ec8e09f75411685205bd0d9d7872cc3622e67c76df44a0a227b278bea04458d5",
-    "org/apache/commons/commons-parent/34/commons-parent-34.pom": "3a2e69d06d641d1f3b293126dc9e2e4ea6563bf8c36c87e0ab6fa4292d04b79c",
-    "org/apache/commons/commons-parent/42/commons-parent-42.pom": "cd313494c670b483ec256972af1698b330e598f807002354eb765479f604b09c",
-    "org/apache/commons/commons-parent/47/commons-parent-47.pom": "8a8ecb570553bf9f1ffae211a8d4ca9ee630c17afe59293368fba7bd9b42fcb7",
-    "org/apache/commons/commons-parent/52/commons-parent-52.pom": "75dbe8f34e98e4c3ff42daae4a2f9eb4cbcd3b5f1047d54460ace906dbb4502e",
-    "org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.jar": "6fe9026a566c6a5001608cf3fc32196641f6c1e5e1986d1037ccdbd5f31ef743",
-    "org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.pom": "78eb9ada74929fcd63d07adc4f49236841a45cc29d5f817bf45801f513fd7e6c",
-    "org/apache/httpcomponents/httpcomponents-client/4.5.13/httpcomponents-client-4.5.13.pom": "9cba594c08db7271d0c20e9845d622bb39e69583910b45e7d5df82f6058d4dd9",
-    "org/apache/httpcomponents/httpcomponents-core/4.4.13/httpcomponents-core-4.4.13.pom": "c554e7008e4517c7ef54e005cc8b74f4c87a54a0ea2c6f57be5d0569df51936b",
-    "org/apache/httpcomponents/httpcomponents-parent/11/httpcomponents-parent-11.pom": "a901f87b115c55070c7ee43efff63e20e7b02d30af2443ae292bf1f4e532d3aa",
-    "org/apache/httpcomponents/httpcore/4.4.13/httpcore-4.4.13.jar": "e06e89d40943245fcfa39ec537cdbfce3762aecde8f9c597780d2b00c2b43424",
-    "org/apache/httpcomponents/httpcore/4.4.13/httpcore-4.4.13.pom": "8f812d9fa7b72a3d4aa7f825278932a5df344b42a6d8398905879431a1bf9a97",
-    "org/apache/maven/maven-artifact/3.8.4/maven-artifact-3.8.4.jar": "4273b4e84805f7350eb61a1eea5debfd71d1147414b3b441b92d535218cdf0ae",
-    "org/apache/maven/maven-artifact/3.8.4/maven-artifact-3.8.4.pom": "3557f18cb3ba2732cd1bac763c6213f4c2de6dcb34c7bc32519a85c949e2ace2",
-    "org/apache/maven/maven-builder-support/3.8.4/maven-builder-support-3.8.4.jar": "b64161e6ffd30782d97c205942bba219d60c53a8f4442e69abdfd428d7691135",
-    "org/apache/maven/maven-builder-support/3.8.4/maven-builder-support-3.8.4.pom": "00ddfa06e1866e4026ce8f2636a267526c512b18d922d8557440f8551fb7bcda",
-    "org/apache/maven/maven-core/3.8.4/maven-core-3.8.4.jar": "2415e64ffbc3ff4e7265268f651623342c7b0a9e0a77c5c54b4e82d1522f3189",
-    "org/apache/maven/maven-core/3.8.4/maven-core-3.8.4.pom": "9c5215adc79c8d593f934363e2c6dda9d552c9a799495d318e3eb4a672d982e1",
-    "org/apache/maven/maven-model-builder/3.8.4/maven-model-builder-3.8.4.jar": "8d0ed4b5cc5c06610f97935982458260165cb7e57c781ca7c9ef8b6e01ce1456",
-    "org/apache/maven/maven-model-builder/3.8.4/maven-model-builder-3.8.4.pom": "385b6af055a1eb46834886fc1c2d341a49f15efd44ccc0fa7895a8538b28c11c",
-    "org/apache/maven/maven-model/3.8.4/maven-model-3.8.4.jar": "91ec0d6d564a12483e1569b0ef72ff3d9e921c5ba07201fa7ab9c7694db8844a",
-    "org/apache/maven/maven-model/3.8.4/maven-model-3.8.4.pom": "c51c635a67896ce79b343139884d94c30a68075eabf3646d03f5f000fadfdc80",
-    "org/apache/maven/maven-parent/34/maven-parent-34.pom": "1a8faf7a6a2b848acb26a959954ee115c0d79dbe75a6206fb3b8c7c2f45a237f",
-    "org/apache/maven/maven-plugin-api/3.8.4/maven-plugin-api-3.8.4.jar": "3aa48d91a54aab6fea95d98218345621eb3952e693ae591d41b63ac5b86eb76a",
-    "org/apache/maven/maven-plugin-api/3.8.4/maven-plugin-api-3.8.4.pom": "151a27e9e61f44f141cf02681360572e6935cab58d99f029c3d08f4aafd65b1d",
-    "org/apache/maven/maven-repository-metadata/3.8.4/maven-repository-metadata-3.8.4.jar": "62a97989068af34eef374bedcca120a1c2b0bd5a2d48460d306944084cc495f9",
-    "org/apache/maven/maven-repository-metadata/3.8.4/maven-repository-metadata-3.8.4.pom": "b283bce8c0558c59a45148380101cae65a95f58fcb0bc0603fee9899b9c7f9bb",
-    "org/apache/maven/maven-resolver-provider/3.8.4/maven-resolver-provider-3.8.4.jar": "046c7d1635f91283b4f7a41b579953857914c7e0d96545b557491537b327e156",
-    "org/apache/maven/maven-resolver-provider/3.8.4/maven-resolver-provider-3.8.4.pom": "4c02b07313e220ccb2e2ba5b69406e461aad3058e969dec3b62b1e4c14715c5a",
-    "org/apache/maven/maven-settings-builder/3.8.4/maven-settings-builder-3.8.4.jar": "7e72b48fcb3c88a146425e3bd1265c3bc4ac546852fe4bbab61064f1dd1835b7",
-    "org/apache/maven/maven-settings-builder/3.8.4/maven-settings-builder-3.8.4.pom": "520a5006a01e6dafa479374a7fd848695cdb90f2d49578f3f7ffdde665052a5a",
-    "org/apache/maven/maven-settings/3.8.4/maven-settings-3.8.4.jar": "4f12ed49761c4b486c171996643d8d80246286ab14489a736ce0dd06e6bc6886",
-    "org/apache/maven/maven-settings/3.8.4/maven-settings-3.8.4.pom": "304028f76ce547982b4c05cb5a0e2ea2a5020b96384ce43705a2de1b8c14c071",
-    "org/apache/maven/maven/3.8.4/maven-3.8.4.pom": "5b6fa7f0b6c50483877590751f5079de10960d4af7260e244883b2197771f32f",
-    "org/apache/maven/resolver/maven-resolver-api/1.6.3/maven-resolver-api-1.6.3.jar": "d0b28ed944058ba4f9be4b54c25d6d5269cc4f3f3c49aa450d4dc2f7e0d552f6",
-    "org/apache/maven/resolver/maven-resolver-api/1.6.3/maven-resolver-api-1.6.3.pom": "116678679dba3d36d799f672c26ee2443480efa1b1bbb8250f06e0dd5a91a795",
-    "org/apache/maven/resolver/maven-resolver-connector-basic/1.6.3/maven-resolver-connector-basic-1.6.3.jar": "52fa1c85e9162c9b0f60511d2d07b74e2a1a9132761bf5ced42da1f09a026f23",
-    "org/apache/maven/resolver/maven-resolver-connector-basic/1.6.3/maven-resolver-connector-basic-1.6.3.pom": "fd62fa62ba83a1372cf05a7bad3f66eb814d475e46b568204f09224e869b745d",
-    "org/apache/maven/resolver/maven-resolver-impl/1.6.3/maven-resolver-impl-1.6.3.jar": "17aaebe6e3e59df8cb5b4ec210196f7084637312b9bc4ff14cb77ad1ae3c381b",
-    "org/apache/maven/resolver/maven-resolver-impl/1.6.3/maven-resolver-impl-1.6.3.pom": "4b41aeb688e244a26d9629c90a286ea284c2fb6550dface2628c7b5a60bc09c7",
-    "org/apache/maven/resolver/maven-resolver-spi/1.6.3/maven-resolver-spi-1.6.3.jar": "17441a39045ac19bc4a8068fb7284facebf6337754bf2bf8f26a76b5f98ed108",
-    "org/apache/maven/resolver/maven-resolver-spi/1.6.3/maven-resolver-spi-1.6.3.pom": "1f8946c471c16703cbb08040bc7d05d7072ba221504a77d64bee785a3f53d7c3",
-    "org/apache/maven/resolver/maven-resolver-transport-file/1.6.3/maven-resolver-transport-file-1.6.3.jar": "dceaf3d095d9aaee0f4abc5c9c05eac76ad82929d6cbbf610ab2350e61d04750",
-    "org/apache/maven/resolver/maven-resolver-transport-file/1.6.3/maven-resolver-transport-file-1.6.3.pom": "af4b6f7e00311f524bfd9bbfebdb84761a3127602ddfa49077c786999243b151",
-    "org/apache/maven/resolver/maven-resolver-transport-http/1.6.3/maven-resolver-transport-http-1.6.3.jar": "0a009a075f3cda76037585e2fdcf9d65e52d38f6d6be4382f1b5257c3a3b2f1b",
-    "org/apache/maven/resolver/maven-resolver-transport-http/1.6.3/maven-resolver-transport-http-1.6.3.pom": "4ef353400ee0a0a102124f143827e6420defac77c0b81b75ad0f18d1bfad9adf",
-    "org/apache/maven/resolver/maven-resolver-util/1.6.3/maven-resolver-util-1.6.3.jar": "cdcad9355b625743f40e4cead9a96353404e010c39c808d23b044be331afa251",
-    "org/apache/maven/resolver/maven-resolver-util/1.6.3/maven-resolver-util-1.6.3.pom": "d1c35e76f4166f13b0a51d565acf967e9c3c79e2ccb69ccbf4fac098e4b7c466",
-    "org/apache/maven/resolver/maven-resolver/1.6.3/maven-resolver-1.6.3.pom": "97397ee75b130ee2bb4a28e0fbb1259595a8361338aba082f8af147398e8a3ec",
-    "org/apache/maven/shared/maven-shared-components/34/maven-shared-components-34.pom": "64d0edb5f21cfff600b1c3ab7d45f9754cd18ba5fbf83b3d1bb7c4849437d8e3",
-    "org/apache/maven/shared/maven-shared-utils/3.3.4/maven-shared-utils-3.3.4.jar": "7925d9c5a0e2040d24b8fae3f612eb399cbffe5838b33ba368777dc7bddf6dda",
-    "org/apache/maven/shared/maven-shared-utils/3.3.4/maven-shared-utils-3.3.4.pom": "bf83482d96f76d63699d63e125e64f4ac73c8178985733662dbd69af9c60339e",
-    "org/checkerframework/checker-compat-qual/2.5.5/checker-compat-qual-2.5.5.jar": "11d134b245e9cacc474514d2d66b5b8618f8039a1465cdc55bbc0b34e0008b7a",
-    "org/checkerframework/checker-compat-qual/2.5.5/checker-compat-qual-2.5.5.pom": "42f21ebd9183be049ee5afc822b345403a5da764037875734a039b0d6e0353be",
-    "org/checkerframework/checker-qual/3.12.0/checker-qual-3.12.0.jar": "ff10785ac2a357ec5de9c293cb982a2cbb605c0309ea4cc1cb9b9bc6dbe7f3cb",
-    "org/checkerframework/checker-qual/3.12.0/checker-qual-3.12.0.pom": "775b7ae36e62820b3b86dc1aa39af37c0ac4b85ff48f7fe485a922a2790f46b9",
-    "org/clojure/clojure/1.10.3/clojure-1.10.3.jar": "7f12472daed8f6b517498aaa2ab13a562475c3edf51478e4581cc761e98979a3",
-    "org/clojure/clojure/1.10.3/clojure-1.10.3.pom": "189c00c433407496a2fbb0eccb37908c94955d91ead1be48156744ecc1816d94",
-    "org/clojure/clojure/1.11.1/clojure-1.11.1.jar": "2381b6e9423ab465151455944903d13a56243d6006b9194afc1bf4f8710cb4de",
-    "org/clojure/clojure/1.11.1/clojure-1.11.1.pom": "20c45a1abedbd8be20aef936050ae31a08c16740b32f8740b8838cde96ffcb8a",
-    "org/clojure/core.async/1.5.644/core.async-1.5.644.jar": "c7890901420932ab0233d99695a53c3d5f9eee2f2d4fbb7d85076c52cc45f447",
-    "org/clojure/core.async/1.5.644/core.async-1.5.644.pom": "dedf42a27f933934695ab13c425223b1d53765ade5e5e2c060080bc0bf4224ca",
-    "org/clojure/core.cache/1.0.225/core.cache-1.0.225.jar": "c153aa947eda5cdbd8a93882c8fbabd5037d4ad7311802b4bcd8015469f6a5b1",
-    "org/clojure/core.cache/1.0.225/core.cache-1.0.225.pom": "39e341f67bfef393e478390d4988f119a779ca449066cb0d33f80b42ff04f43d",
-    "org/clojure/core.memoize/1.0.253/core.memoize-1.0.253.jar": "4a910585182ab326c1d0a20d34315be1563b5a58437d41c021dd7fe9911e1ed6",
-    "org/clojure/core.memoize/1.0.253/core.memoize-1.0.253.pom": "84c2fab7a32ca3c1e40c41a6ecc9bd536e947b30580e77b8d5dc232a34925eac",
-    "org/clojure/core.specs.alpha/0.2.56/core.specs.alpha-0.2.56.jar": "fcf442bde02b04a863f2fcc58ee6a2a30c4cf0c970f7dab85634f0ab711166b6",
-    "org/clojure/core.specs.alpha/0.2.56/core.specs.alpha-0.2.56.pom": "01aaf17483ff1c7482c92a07295d7e7bc6e3b3322df44b29b5738d020ff00740",
-    "org/clojure/core.specs.alpha/0.2.62/core.specs.alpha-0.2.62.jar": "06eea8c070bbe45c158567e443439681bc8c46e9123414f81bfa32ba42d6cbc8",
-    "org/clojure/core.specs.alpha/0.2.62/core.specs.alpha-0.2.62.pom": "1778bbd138bd18590b8054be9d919d1beb6809f85b76e5c6285b67d4077d300e",
-    "org/clojure/data.codec/0.1.0/data.codec-0.1.0.jar": "683d681950403c61c236354181eba1b5c8daf6c13581ea1389934a7d5eb28e07",
-    "org/clojure/data.codec/0.1.0/data.codec-0.1.0.pom": "f13d996846d6d7a702436265aa38632a674692025a418a56695c502813ddda78",
-    "org/clojure/data.csv/1.0.0/data.csv-1.0.0.jar": "92170a3ca50b6c8d90322ddeaf462fcb3c83cd42dec96db85f2173c502765190",
-    "org/clojure/data.csv/1.0.0/data.csv-1.0.0.pom": "25a3978a8f654b6042eeca8afaac48f4d796117add2ed1008bd271b442e6288f",
-    "org/clojure/data.json/2.4.0/data.json-2.4.0.jar": "ec3f2f994e1eedd420313c452ba5518c5f5c97be5152dfed5650bc6611486adf",
-    "org/clojure/data.json/2.4.0/data.json-2.4.0.pom": "a42ea70f17b517666ad8492a1bfa917de5defac7b47c516f6d0d4d89c2780cf4",
-    "org/clojure/data.priority-map/1.1.0/data.priority-map-1.1.0.jar": "fe51af4472fa0f1bfd66f3871de55076402ff6615a74bcb17b37c402a0ea6f4c",
-    "org/clojure/data.priority-map/1.1.0/data.priority-map-1.1.0.pom": "465200f94f56d8868e0fd7aa0becc62ffb02cfaf420a49ad117910e63af5dffe",
-    "org/clojure/data.xml/0.2.0-alpha6/data.xml-0.2.0-alpha6.jar": "90882b4ac6f610e5fd711f885545a4909023b63d8e7d595918d97d181b59a828",
-    "org/clojure/data.xml/0.2.0-alpha6/data.xml-0.2.0-alpha6.pom": "1f8880b9eb2484686c9eca3c306845d8db91e76a4d1c5f6457554edecca76336",
-    "org/clojure/java.classpath/1.0.0/java.classpath-1.0.0.jar": "c14e0e10304a5e5cfd2cc742fbdefac1f5293eec6070c2ffe8903fb5c7fe7d6f",
-    "org/clojure/java.classpath/1.0.0/java.classpath-1.0.0.pom": "0be013851457fc24c434ce45534643f226e5c10800486253fd373f2e09545e28",
-    "org/clojure/pom.contrib/0.0.25/pom.contrib-0.0.25.pom": "ebc7b376e56d83f6c484cdb1d371efdc0130ddbbcade7d6da6e354f4e426fc8b",
-    "org/clojure/pom.contrib/0.2.2/pom.contrib-0.2.2.pom": "e0ea227c49c5c3e30754cd26fcc57be7e4de973fe43aa5cc6667401ec5c10323",
-    "org/clojure/pom.contrib/0.3.0/pom.contrib-0.3.0.pom": "7f182b3b2a543e057460bf93ffc5e9cef6ac527df1a1376a7d9922ebe79ef119",
-    "org/clojure/pom.contrib/1.0.0/pom.contrib-1.0.0.pom": "1011faae5c9e496858e4c650ba33713abd469a5d52e00aeb7f5b01a2bcaf47e9",
-    "org/clojure/pom.contrib/1.1.0/pom.contrib-1.1.0.pom": "10ece4bb5f9829010dc16561f42ebb83baf2f47605b51f9105b92f3caa089715",
-    "org/clojure/spec.alpha/0.2.194/spec.alpha-0.2.194.jar": "cf6899f985298c64b13ea129946ad9028dee8dadf0eab9ae18e455027d38249c",
-    "org/clojure/spec.alpha/0.2.194/spec.alpha-0.2.194.pom": "5a11f0e1e8b3c052e651c498c6945b44db3535bf2c18719fdcf65df1f88b13e6",
-    "org/clojure/spec.alpha/0.3.218/spec.alpha-0.3.218.jar": "67ec898eb55c66a957a55279dd85d1376bb994bd87668b2b0de1eb3b97e8aae0",
-    "org/clojure/spec.alpha/0.3.218/spec.alpha-0.3.218.pom": "6d8de14c3ac875760c5ff909562ff9873077031c6ab939f1cb139e169fe90758",
-    "org/clojure/tools.analyzer.jvm/1.2.1/tools.analyzer.jvm-1.2.1.jar": "f07259864b8d0dc5935ba840c737aedb35fd9b0db630d544f9fa278184635927",
-    "org/clojure/tools.analyzer.jvm/1.2.1/tools.analyzer.jvm-1.2.1.pom": "ba7218cc0eb4e1595f2676587819c6aa0bd07c287644d8d995fa13d3c3d74c03",
-    "org/clojure/tools.analyzer/1.1.0/tools.analyzer-1.1.0.jar": "1368b6bc3bddf7c398d5784d10548f44c4ed2d7c01ea105ac0efde9cf5e0df21",
-    "org/clojure/tools.analyzer/1.1.0/tools.analyzer-1.1.0.pom": "3720712fb92761a35c94d0ee415d6bf15841ef469f073646776875e79dc9b706",
-    "org/clojure/tools.cli/1.0.206/tools.cli-1.0.206.jar": "6b97d2691919b9ea944a898fec798a90ecb81a17732916edbc73a6f5afd1f616",
-    "org/clojure/tools.cli/1.0.206/tools.cli-1.0.206.pom": "fd00cd0b8ab5c9f7c16958b056502dbaf72a47a4cb886e8002b5b0dbbb38f49e",
-    "org/clojure/tools.deps.alpha/0.12.1148/tools.deps.alpha-0.12.1148.jar": "3b375c0b50aee4a8373dae2d1ef985fa439d19c05db51a954bfedb2627e703ff",
-    "org/clojure/tools.deps.alpha/0.12.1148/tools.deps.alpha-0.12.1148.pom": "652d0ac8ffc76b5089bd04cb90c44d16c4d687ece70f3018e5a92fc07e0a0431",
-    "org/clojure/tools.gitlibs/2.4.172/tools.gitlibs-2.4.172.jar": "f8bc385c7bba1b2e0122e7f3c454a1c9161f639370d34bb4b2afe9e80f7e0890",
-    "org/clojure/tools.gitlibs/2.4.172/tools.gitlibs-2.4.172.pom": "6323060c1d0b1748a06b05df3e8f23b033232586be814c296556e8f76434ab8f",
-    "org/clojure/tools.logging/1.2.1/tools.logging-1.2.1.jar": "ca9999416e3cc5b72034936c8bcc599f2a86850ebb9ceb4316a4a2687f315b6b",
-    "org/clojure/tools.logging/1.2.1/tools.logging-1.2.1.pom": "260e76be75e7d06312530cc8bf3f74b0e34a2cb9dc3de231ff0e6712ffb7a378",
-    "org/clojure/tools.namespace/1.2.0/tools.namespace-1.2.0.jar": "bc9ac99051089473943d5b3d3087d09d2d365adae06440671e5fb8a0061bd7e9",
-    "org/clojure/tools.namespace/1.2.0/tools.namespace-1.2.0.pom": "b525e067c837f438fde000d78afaca1ded85d00c0d479d287aa9f4a1ae36b5ba",
-    "org/clojure/tools.reader/1.3.6/tools.reader-1.3.6.jar": "11d1b31f2c65c3355b292bb9b44b8fcafda54b44da63e34ab97b79a8ab3bb8e0",
-    "org/clojure/tools.reader/1.3.6/tools.reader-1.3.6.pom": "aef5ee828b7cb14a1c58f45b9f8a10ff340c5769925ea0ef5c35d1e49d920bea",
-    "org/codehaus/plexus/plexus-cipher/2.0/plexus-cipher-2.0.jar": "9a7f1b5c5a9effd61eadfd8731452a2f76a8e79111fac391ef75ea801bea203a",
-    "org/codehaus/plexus/plexus-cipher/2.0/plexus-cipher-2.0.pom": "04842f331b0225b85a5e20439710d228ea7a6302abe6d53c9c9846fbc5bf99ff",
-    "org/codehaus/plexus/plexus-classworlds/2.6.0/plexus-classworlds-2.6.0.jar": "52f77c5ec49f787c9c417ebed5d6efd9922f44a202f217376e4f94c0d74f3549",
-    "org/codehaus/plexus/plexus-classworlds/2.6.0/plexus-classworlds-2.6.0.pom": "469a6c59f92effa62c0797ce7d52d2c03cf8ee1034b923c360dd78a9f505a7ba",
-    "org/codehaus/plexus/plexus-component-annotations/2.1.0/plexus-component-annotations-2.1.0.jar": "bde3617ce9b5bcf9584126046080043af6a4b3baea40a3b153f02e7bbc32acac",
-    "org/codehaus/plexus/plexus-component-annotations/2.1.0/plexus-component-annotations-2.1.0.pom": "0670b605255f7dc9a454daaec7912918ccf1b5475cbfca374363b51fcfd4ea00",
-    "org/codehaus/plexus/plexus-containers/2.1.0/plexus-containers-2.1.0.pom": "94d5aedb3c46023265396527cf8ce7fc944b7bd79e4ebab907386418eb5a08d7",
-    "org/codehaus/plexus/plexus-interpolation/1.26/plexus-interpolation-1.26.jar": "b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662",
-    "org/codehaus/plexus/plexus-interpolation/1.26/plexus-interpolation-1.26.pom": "e1c10b3a6335641eb74a668daa9ee86ae4ab06610174e59ba07c8c68042327f7",
-    "org/codehaus/plexus/plexus-sec-dispatcher/2.0/plexus-sec-dispatcher-2.0.jar": "873139960c4c780176dda580b003a2c4bf82188bdce5bb99234e224ef7acfceb",
-    "org/codehaus/plexus/plexus-sec-dispatcher/2.0/plexus-sec-dispatcher-2.0.pom": "9b28bb307017938a94d06c85b2b099bc46912b859d084fb293e569f432eadb7c",
-    "org/codehaus/plexus/plexus-utils/3.3.0/plexus-utils-3.3.0.pom": "79c9792073fdee3cdbebd61a76ba8c2dd11624a9f85d128bae56bda19e20475c",
-    "org/codehaus/plexus/plexus-utils/3.4.1/plexus-utils-3.4.1.jar": "52d85e04b3918722af11d12855b4a8257df96a0e76c8f4e3852e6faa851f357b",
-    "org/codehaus/plexus/plexus-utils/3.4.1/plexus-utils-3.4.1.pom": "b144cff9b1c6259fec4fee5bdfc0f360d69c23abd4ea6e544533a949b69e3582",
-    "org/codehaus/plexus/plexus/5.1/plexus-5.1.pom": "a343e44ff5796aed0ea60be11454c935ce20ab1c5f164acc8da574482dcbc7e9",
-    "org/codehaus/plexus/plexus/8/plexus-8.pom": "ffa349db04e7abf65885bdc5a2062f4197c0ff9d3f1f4e2aa5720b77233f742c",
-    "org/eclipse/jetty/jetty-client/9.4.44.v20210927/jetty-client-9.4.44.v20210927.jar": "81c335a33fea19ab71470e2b89295161f98a773fd3dfba1f4c4f9a358608090d",
-    "org/eclipse/jetty/jetty-client/9.4.44.v20210927/jetty-client-9.4.44.v20210927.pom": "1627338bbacba002b74047d273f1b3e252e177349a0e699cf39b0eb8e473a010",
-    "org/eclipse/jetty/jetty-http/9.4.44.v20210927/jetty-http-9.4.44.v20210927.jar": "0a09fac4c0ea826f920cfe8d5beced61dcd8fec0eae99b88c7619609fa0dc403",
-    "org/eclipse/jetty/jetty-http/9.4.44.v20210927/jetty-http-9.4.44.v20210927.pom": "ee853d5c360d9ad46a7694e95f0aeb6b10b2e407ea12c8c423a1bec4356f92ae",
-    "org/eclipse/jetty/jetty-io/9.4.44.v20210927/jetty-io-9.4.44.v20210927.jar": "3c6f1105500921aa4f9687c3a1b5fd9eba4661a5f438aa089829c2ecc9726745",
-    "org/eclipse/jetty/jetty-io/9.4.44.v20210927/jetty-io-9.4.44.v20210927.pom": "fca766c2c259b63c669e8e49bbbdfc0a84b4d554a276589065ae0c0db828e9ad",
-    "org/eclipse/jetty/jetty-project/9.4.44.v20210927/jetty-project-9.4.44.v20210927.pom": "fc1f9083e29d415aeec979b6ebf1506e536c05bdbecb5f601a192ccc98e4a0ad",
-    "org/eclipse/jetty/jetty-util/9.4.44.v20210927/jetty-util-9.4.44.v20210927.jar": "539179024520b614f62d5d83f25bea111f7b991c399e5f737fa6aa2750489079",
-    "org/eclipse/jetty/jetty-util/9.4.44.v20210927/jetty-util-9.4.44.v20210927.pom": "36440e0d44cea802a45b704191d8c3b4d67c8c394c8a02ab78c571ef7a1cd2ba",
-    "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.5/org.eclipse.sisu.inject-0.3.5.jar": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13",
-    "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.5/org.eclipse.sisu.inject-0.3.5.pom": "c2976972b4242ffd8604716d8475f56755da0fa28618344ec4e5327810696d71",
-    "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.5/org.eclipse.sisu.plexus-0.3.5.jar": "7e4c61096d70826f20f7a7d55c59a5528e7aa5ad247ee2dfe544e4dd25f6a784",
-    "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.5/org.eclipse.sisu.plexus-0.3.5.pom": "786523c9d78258a74aa13447a1676c2172acfdf432165d7adae2b7876d2d83d3",
-    "org/eclipse/sisu/sisu-inject/0.3.5/sisu-inject-0.3.5.pom": "5f32ecab9c8f6dff1f9e41b853e40d8f23a2508219154ef67cc00d4556f5f5dd",
-    "org/eclipse/sisu/sisu-plexus/0.3.5/sisu-plexus-0.3.5.pom": "6eba0902efd899aec0d8d19ac3cbc53123cd41139fe0e1d29cc5c874a791b9de",
-    "org/junit/junit-bom/5.7.2/junit-bom-5.7.2.pom": "cd14aaa869991f82021c585d570d31ff342bcba58bb44233b70193771b96487b",
-    "org/junit/junit-bom/5.8.1/junit-bom-5.8.1.pom": "ef7dc47f8e4a16864f4779728e87ed78539819e4fb892768a9da6b8ef903f863",
-    "org/ow2/asm/asm-parent/5.2/asm-parent-5.2.pom": "cbfacd5dd812db16dc910994007fe58d9402a25507f81a1c2218e15c2c1bedfa",
-    "org/ow2/asm/asm/5.2/asm-5.2.jar": "3e5ea0d7da2c5155ef4f470d9092d42de34e3f53db6589c7c07d6721adf4ba3e",
-    "org/ow2/asm/asm/5.2/asm-5.2.pom": "289f7fbbd7b0c576d5286e8adcf8d0735134d3915efea6436e2be35c11fcf050",
-    "org/ow2/ow2/1.3/ow2-1.3.pom": "51215c67d2c068d8b7d2f6f80f51372a098075deccc448d4bdd7b987ba8328fb",
-    "org/slf4j/jcl-over-slf4j/1.7.30/jcl-over-slf4j-1.7.30.jar": "71e9ee37b9e4eb7802a2acc5f41728a4cf3915e7483d798db3b4ff2ec8847c50",
-    "org/slf4j/jcl-over-slf4j/1.7.30/jcl-over-slf4j-1.7.30.pom": "16736dd4e71e7097b758be1553506f19a541eeb7766dc36355adaed7a536b455",
-    "org/slf4j/slf4j-api/1.7.32/slf4j-api-1.7.32.jar": "3624f8474c1af46d75f98bc097d7864a323c81b3808aa43689a6e1c601c027be",
-    "org/slf4j/slf4j-api/1.7.32/slf4j-api-1.7.32.pom": "001cde5b3c6ba91070425cfe9f2e695e4aeb8bc290a2d4cd96531127ab244fe5",
-    "org/slf4j/slf4j-nop/1.7.32/slf4j-nop-1.7.32.jar": "f2d20b60b2b87fc1ca904e0cd4520deeeebf8a9c5b723ae2493cc4219389d782",
-    "org/slf4j/slf4j-nop/1.7.32/slf4j-nop-1.7.32.pom": "5c1bb97f392cf7bc9d04fd1488d69857797036708ddd7f99cb39f3ec7518d733",
-    "org/slf4j/slf4j-parent/1.7.30/slf4j-parent-1.7.30.pom": "11647956e48a0c5bfb3ac33f6da7e83f341002b6857efd335a505b687be34b75",
-    "org/slf4j/slf4j-parent/1.7.32/slf4j-parent-1.7.32.pom": "5ab349d0f4c7bc08ed0ef1f4d9386cb1940a2f4d6f152150e16dbbecc0b83c70",
-    "org/sonatype/oss/oss-parent/5/oss-parent-5.pom": "1678d4120a585d8a630131aeec4c524d928398583b7eab616ee7d5a87f520d3d",
-    "org/sonatype/oss/oss-parent/7/oss-parent-7.pom": "b51f8867c92b6a722499557fc3a1fdea77bdf9ef574722fe90ce436a29559454",
-    "org/sonatype/oss/oss-parent/9/oss-parent-9.pom": "fb40265f982548212ff82e362e59732b2187ec6f0d80182885c14ef1f982827a"
+    "aopalliance/aopalliance/1.0/aopalliance-1.0.jar": {
+      "sha256": "0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08"
+    },
+    "aopalliance/aopalliance/1.0/aopalliance-1.0.pom": {
+      "sha256": "26e82330157d6b844b67a8064945e206581e772977183e3e31fec6058aa9a59b"
+    },
+    "com/cognitect/aws/api/0.8.539/api-0.8.539.jar": {
+      "sha256": "614e67f769bb0c6480e793557ea4e0d2365727ce809ed814ecf99501b9db5da9"
+    },
+    "com/cognitect/aws/api/0.8.539/api-0.8.539.pom": {
+      "sha256": "5df71fed2040cbad327fe02d542b51e1945f446bc42d3a1afbaa77f13cdd89d4"
+    },
+    "com/cognitect/aws/endpoints/1.1.12.150/endpoints-1.1.12.150.jar": {
+      "sha256": "a98fe61774d25891e199fc6d6b8ea405c3b08de220bdff0926afed21b789944f"
+    },
+    "com/cognitect/aws/endpoints/1.1.12.150/endpoints-1.1.12.150.pom": {
+      "sha256": "deffd3470cc04d158b9f6aa9d617142e6874ba6a112b4fbec6e036c976cc76d3"
+    },
+    "com/cognitect/aws/s3/814.2.1053.0/s3-814.2.1053.0.jar": {
+      "sha256": "ab1ec40e9c7268bd69e08d8111a845cf68ab7083b4c15e78a573b29e52290caf"
+    },
+    "com/cognitect/aws/s3/814.2.1053.0/s3-814.2.1053.0.pom": {
+      "sha256": "04c48d8847fa6beaf7e9423355fc15364d1de73fbe4aee90435924fcf0f49788"
+    },
+    "com/cognitect/http-client/1.0.110/http-client-1.0.110.jar": {
+      "sha256": "9be8bdef307b4a1e44302a3346911a139a5e5db8507cb51bf7c41df96623192d"
+    },
+    "com/cognitect/http-client/1.0.110/http-client-1.0.110.pom": {
+      "sha256": "42dec0f6a0dfe3bf7b0c296c1d0106dd25dcc784e922ab532042b3f1869e380e"
+    },
+    "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar": {
+      "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7"
+    },
+    "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.pom": {
+      "sha256": "19889dbdf1b254b2601a5ee645b8147a974644882297684c798afe5d63d78dfe"
+    },
+    "com/google/errorprone/error_prone_annotations/2.7.1/error_prone_annotations-2.7.1.jar": {
+      "sha256": "cd5257c08a246cf8628817ae71cb822be192ef91f6881ca4a3fcff4f1de1cff3"
+    },
+    "com/google/errorprone/error_prone_annotations/2.7.1/error_prone_annotations-2.7.1.pom": {
+      "sha256": "31a872e1149c5f3a8bc05fb4de455e5ea608ecfad1af222cb7637ca6c762ee25"
+    },
+    "com/google/errorprone/error_prone_parent/2.7.1/error_prone_parent-2.7.1.pom": {
+      "sha256": "0a6e242e28104e8093405ae37969660a438b71c4c1b73fc4ff716db89da88de6"
+    },
+    "com/google/google/5/google-5.pom": {
+      "sha256": "e09d345e73ca3fbca7f3e05f30deb74e9d39dd6b79a93fee8c511f23417b6828"
+    },
+    "com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar": {
+      "sha256": "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26"
+    },
+    "com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.pom": {
+      "sha256": "e96042ce78fecba0da2be964522947c87b40a291b5fd3cd672a434924103c4b9"
+    },
+    "com/google/guava/guava-parent/26.0-android/guava-parent-26.0-android.pom": {
+      "sha256": "f8698ab46ca996ce889c1afc8ca4f25eb8ac6b034dc898d4583742360016cc04"
+    },
+    "com/google/guava/guava-parent/31.0.1-android/guava-parent-31.0.1-android.pom": {
+      "sha256": "30a51d34b075c9b4eb6a2da3fba6c1f5047b45225a3a03aebcefc0b7880e5735"
+    },
+    "com/google/guava/guava/31.0.1-android/guava-31.0.1-android.jar": {
+      "sha256": "9425a423a4cb9d9db0356300722d9bd8e634cf539f29d97bb84f457cccd16eb8"
+    },
+    "com/google/guava/guava/31.0.1-android/guava-31.0.1-android.pom": {
+      "sha256": "13d4e2998aac652fc6d7b9eaf3e495fa2952bf98ef68a2c49aa5eaa0bbe731a9"
+    },
+    "com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar": {
+      "sha256": "b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99"
+    },
+    "com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.pom": {
+      "sha256": "18d4b1db26153d4e55079ce1f76bb1fe05cdb862ef9954a88cbcc4ff38b8679b"
+    },
+    "com/google/inject/guice-parent/4.2.2/guice-parent-4.2.2.pom": {
+      "sha256": "5a74ba3d22be1ac13b9e782f13a7d957db2a24ded359481394c9e889f1c037d6"
+    },
+    "com/google/inject/guice/4.2.2/guice-4.2.2-no_aop.jar": {
+      "sha256": "0f4f5fb28609a4d2b38b7f7128be7cf9b541f25283d71b4e56066d99683aafff"
+    },
+    "com/google/inject/guice/4.2.2/guice-4.2.2.pom": {
+      "sha256": "06f3c3ddad57b30bfe88655456a04731e56a78ad0dd909e65c71881003b96479"
+    },
+    "com/google/j2objc/j2objc-annotations/1.3/j2objc-annotations-1.3.jar": {
+      "sha256": "21af30c92267bd6122c0e0b4d20cccb6641a37eaf956c6540ec471d584e64a7b"
+    },
+    "com/google/j2objc/j2objc-annotations/1.3/j2objc-annotations-1.3.pom": {
+      "sha256": "5faca824ba115bee458730337dfdb2fcea46ba2fd774d4304edbf30fa6a3f055"
+    },
+    "commons-codec/commons-codec/1.11/commons-codec-1.11.jar": {
+      "sha256": "e599d5318e97aa48f42136a2927e6dfa4e8881dff0e6c8e3109ddbbff51d7b7d"
+    },
+    "commons-codec/commons-codec/1.11/commons-codec-1.11.pom": {
+      "sha256": "c1e7140d1dea8fdf3528bc1e3c5444ac0b541297311f45f9806c213ec3ee9a10"
+    },
+    "commons-io/commons-io/2.11.0/commons-io-2.11.0.jar": {
+      "sha256": "961b2f6d87dbacc5d54abf45ab7a6e2495f89b75598962d8c723cea9bc210908"
+    },
+    "commons-io/commons-io/2.11.0/commons-io-2.11.0.pom": {
+      "sha256": "2e016fd7e3244b5f2c20acad834d93aa4790486ee1e4564641361a3e831eef59"
+    },
+    "commons-logging/commons-logging/1.2/commons-logging-1.2.jar": {
+      "sha256": "daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636"
+    },
+    "commons-logging/commons-logging/1.2/commons-logging-1.2.pom": {
+      "sha256": "c91ab5aa570d86f6fd07cc158ec6bc2c50080402972ee9179fe24100739fbb20"
+    },
+    "javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2.jar": {
+      "sha256": "5909b396ca3a2be10d0eea32c74ef78d816e1b4ead21de1d78de1f890d033e04"
+    },
+    "javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2.pom": {
+      "sha256": "52d73f35f7e638ce3cb56546f879c20e7f7019f72aa20cde1fa80e97865dfd40"
+    },
+    "javax/inject/javax.inject/1/javax.inject-1.jar": {
+      "sha256": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff"
+    },
+    "javax/inject/javax.inject/1/javax.inject-1.pom": {
+      "sha256": "943e12b100627804638fa285805a0ab788a680266531e650921ebfe4621a8bfa"
+    },
+    "net/java/jvnet-parent/3/jvnet-parent-3.pom": {
+      "sha256": "30f5789efa39ddbf96095aada3fc1260c4561faf2f714686717cb2dc5049475a"
+    },
+    "org/apache/apache/13/apache-13.pom": {
+      "sha256": "ff513db0361fd41237bef4784968bc15aae478d4ec0a9496f811072ccaf3841d"
+    },
+    "org/apache/apache/18/apache-18.pom": {
+      "sha256": "7831307285fd475bbc36b20ae38e7882f11c3153b1d5930f852d44eda8f33c17"
+    },
+    "org/apache/apache/19/apache-19.pom": {
+      "sha256": "91f7a33096ea69bac2cbaf6d01feb934cac002c48d8c8cfa9c240b40f1ec21df"
+    },
+    "org/apache/apache/21/apache-21.pom": {
+      "sha256": "af10c108da014f17cafac7b52b2b4b5a3a1c18265fa2af97a325d9143537b380"
+    },
+    "org/apache/apache/23/apache-23.pom": {
+      "sha256": "bc10624e0623f36577fac5639ca2936d3240ed152fb6d8d533ab4d270543491c"
+    },
+    "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar": {
+      "sha256": "dac807f65b07698ff39b1b07bfef3d87ae3fd46d91bbf8a2bc02b2a831616f68"
+    },
+    "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.pom": {
+      "sha256": "ec8e09f75411685205bd0d9d7872cc3622e67c76df44a0a227b278bea04458d5"
+    },
+    "org/apache/commons/commons-parent/34/commons-parent-34.pom": {
+      "sha256": "3a2e69d06d641d1f3b293126dc9e2e4ea6563bf8c36c87e0ab6fa4292d04b79c"
+    },
+    "org/apache/commons/commons-parent/42/commons-parent-42.pom": {
+      "sha256": "cd313494c670b483ec256972af1698b330e598f807002354eb765479f604b09c"
+    },
+    "org/apache/commons/commons-parent/47/commons-parent-47.pom": {
+      "sha256": "8a8ecb570553bf9f1ffae211a8d4ca9ee630c17afe59293368fba7bd9b42fcb7"
+    },
+    "org/apache/commons/commons-parent/52/commons-parent-52.pom": {
+      "sha256": "75dbe8f34e98e4c3ff42daae4a2f9eb4cbcd3b5f1047d54460ace906dbb4502e"
+    },
+    "org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.jar": {
+      "sha256": "6fe9026a566c6a5001608cf3fc32196641f6c1e5e1986d1037ccdbd5f31ef743"
+    },
+    "org/apache/httpcomponents/httpclient/4.5.13/httpclient-4.5.13.pom": {
+      "sha256": "78eb9ada74929fcd63d07adc4f49236841a45cc29d5f817bf45801f513fd7e6c"
+    },
+    "org/apache/httpcomponents/httpcomponents-client/4.5.13/httpcomponents-client-4.5.13.pom": {
+      "sha256": "9cba594c08db7271d0c20e9845d622bb39e69583910b45e7d5df82f6058d4dd9"
+    },
+    "org/apache/httpcomponents/httpcomponents-core/4.4.13/httpcomponents-core-4.4.13.pom": {
+      "sha256": "c554e7008e4517c7ef54e005cc8b74f4c87a54a0ea2c6f57be5d0569df51936b"
+    },
+    "org/apache/httpcomponents/httpcomponents-parent/11/httpcomponents-parent-11.pom": {
+      "sha256": "a901f87b115c55070c7ee43efff63e20e7b02d30af2443ae292bf1f4e532d3aa"
+    },
+    "org/apache/httpcomponents/httpcore/4.4.13/httpcore-4.4.13.jar": {
+      "sha256": "e06e89d40943245fcfa39ec537cdbfce3762aecde8f9c597780d2b00c2b43424"
+    },
+    "org/apache/httpcomponents/httpcore/4.4.13/httpcore-4.4.13.pom": {
+      "sha256": "8f812d9fa7b72a3d4aa7f825278932a5df344b42a6d8398905879431a1bf9a97"
+    },
+    "org/apache/maven/maven-artifact/3.8.4/maven-artifact-3.8.4.jar": {
+      "sha256": "4273b4e84805f7350eb61a1eea5debfd71d1147414b3b441b92d535218cdf0ae"
+    },
+    "org/apache/maven/maven-artifact/3.8.4/maven-artifact-3.8.4.pom": {
+      "sha256": "3557f18cb3ba2732cd1bac763c6213f4c2de6dcb34c7bc32519a85c949e2ace2"
+    },
+    "org/apache/maven/maven-builder-support/3.8.4/maven-builder-support-3.8.4.jar": {
+      "sha256": "b64161e6ffd30782d97c205942bba219d60c53a8f4442e69abdfd428d7691135"
+    },
+    "org/apache/maven/maven-builder-support/3.8.4/maven-builder-support-3.8.4.pom": {
+      "sha256": "00ddfa06e1866e4026ce8f2636a267526c512b18d922d8557440f8551fb7bcda"
+    },
+    "org/apache/maven/maven-core/3.8.4/maven-core-3.8.4.jar": {
+      "sha256": "2415e64ffbc3ff4e7265268f651623342c7b0a9e0a77c5c54b4e82d1522f3189"
+    },
+    "org/apache/maven/maven-core/3.8.4/maven-core-3.8.4.pom": {
+      "sha256": "9c5215adc79c8d593f934363e2c6dda9d552c9a799495d318e3eb4a672d982e1"
+    },
+    "org/apache/maven/maven-model-builder/3.8.4/maven-model-builder-3.8.4.jar": {
+      "sha256": "8d0ed4b5cc5c06610f97935982458260165cb7e57c781ca7c9ef8b6e01ce1456"
+    },
+    "org/apache/maven/maven-model-builder/3.8.4/maven-model-builder-3.8.4.pom": {
+      "sha256": "385b6af055a1eb46834886fc1c2d341a49f15efd44ccc0fa7895a8538b28c11c"
+    },
+    "org/apache/maven/maven-model/3.8.4/maven-model-3.8.4.jar": {
+      "sha256": "91ec0d6d564a12483e1569b0ef72ff3d9e921c5ba07201fa7ab9c7694db8844a"
+    },
+    "org/apache/maven/maven-model/3.8.4/maven-model-3.8.4.pom": {
+      "sha256": "c51c635a67896ce79b343139884d94c30a68075eabf3646d03f5f000fadfdc80"
+    },
+    "org/apache/maven/maven-parent/34/maven-parent-34.pom": {
+      "sha256": "1a8faf7a6a2b848acb26a959954ee115c0d79dbe75a6206fb3b8c7c2f45a237f"
+    },
+    "org/apache/maven/maven-plugin-api/3.8.4/maven-plugin-api-3.8.4.jar": {
+      "sha256": "3aa48d91a54aab6fea95d98218345621eb3952e693ae591d41b63ac5b86eb76a"
+    },
+    "org/apache/maven/maven-plugin-api/3.8.4/maven-plugin-api-3.8.4.pom": {
+      "sha256": "151a27e9e61f44f141cf02681360572e6935cab58d99f029c3d08f4aafd65b1d"
+    },
+    "org/apache/maven/maven-repository-metadata/3.8.4/maven-repository-metadata-3.8.4.jar": {
+      "sha256": "62a97989068af34eef374bedcca120a1c2b0bd5a2d48460d306944084cc495f9"
+    },
+    "org/apache/maven/maven-repository-metadata/3.8.4/maven-repository-metadata-3.8.4.pom": {
+      "sha256": "b283bce8c0558c59a45148380101cae65a95f58fcb0bc0603fee9899b9c7f9bb"
+    },
+    "org/apache/maven/maven-resolver-provider/3.8.4/maven-resolver-provider-3.8.4.jar": {
+      "sha256": "046c7d1635f91283b4f7a41b579953857914c7e0d96545b557491537b327e156"
+    },
+    "org/apache/maven/maven-resolver-provider/3.8.4/maven-resolver-provider-3.8.4.pom": {
+      "sha256": "4c02b07313e220ccb2e2ba5b69406e461aad3058e969dec3b62b1e4c14715c5a"
+    },
+    "org/apache/maven/maven-settings-builder/3.8.4/maven-settings-builder-3.8.4.jar": {
+      "sha256": "7e72b48fcb3c88a146425e3bd1265c3bc4ac546852fe4bbab61064f1dd1835b7"
+    },
+    "org/apache/maven/maven-settings-builder/3.8.4/maven-settings-builder-3.8.4.pom": {
+      "sha256": "520a5006a01e6dafa479374a7fd848695cdb90f2d49578f3f7ffdde665052a5a"
+    },
+    "org/apache/maven/maven-settings/3.8.4/maven-settings-3.8.4.jar": {
+      "sha256": "4f12ed49761c4b486c171996643d8d80246286ab14489a736ce0dd06e6bc6886"
+    },
+    "org/apache/maven/maven-settings/3.8.4/maven-settings-3.8.4.pom": {
+      "sha256": "304028f76ce547982b4c05cb5a0e2ea2a5020b96384ce43705a2de1b8c14c071"
+    },
+    "org/apache/maven/maven/3.8.4/maven-3.8.4.pom": {
+      "sha256": "5b6fa7f0b6c50483877590751f5079de10960d4af7260e244883b2197771f32f"
+    },
+    "org/apache/maven/resolver/maven-resolver-api/1.6.3/maven-resolver-api-1.6.3.jar": {
+      "sha256": "d0b28ed944058ba4f9be4b54c25d6d5269cc4f3f3c49aa450d4dc2f7e0d552f6"
+    },
+    "org/apache/maven/resolver/maven-resolver-api/1.6.3/maven-resolver-api-1.6.3.pom": {
+      "sha256": "116678679dba3d36d799f672c26ee2443480efa1b1bbb8250f06e0dd5a91a795"
+    },
+    "org/apache/maven/resolver/maven-resolver-connector-basic/1.6.3/maven-resolver-connector-basic-1.6.3.jar": {
+      "sha256": "52fa1c85e9162c9b0f60511d2d07b74e2a1a9132761bf5ced42da1f09a026f23"
+    },
+    "org/apache/maven/resolver/maven-resolver-connector-basic/1.6.3/maven-resolver-connector-basic-1.6.3.pom": {
+      "sha256": "fd62fa62ba83a1372cf05a7bad3f66eb814d475e46b568204f09224e869b745d"
+    },
+    "org/apache/maven/resolver/maven-resolver-impl/1.6.3/maven-resolver-impl-1.6.3.jar": {
+      "sha256": "17aaebe6e3e59df8cb5b4ec210196f7084637312b9bc4ff14cb77ad1ae3c381b"
+    },
+    "org/apache/maven/resolver/maven-resolver-impl/1.6.3/maven-resolver-impl-1.6.3.pom": {
+      "sha256": "4b41aeb688e244a26d9629c90a286ea284c2fb6550dface2628c7b5a60bc09c7"
+    },
+    "org/apache/maven/resolver/maven-resolver-spi/1.6.3/maven-resolver-spi-1.6.3.jar": {
+      "sha256": "17441a39045ac19bc4a8068fb7284facebf6337754bf2bf8f26a76b5f98ed108"
+    },
+    "org/apache/maven/resolver/maven-resolver-spi/1.6.3/maven-resolver-spi-1.6.3.pom": {
+      "sha256": "1f8946c471c16703cbb08040bc7d05d7072ba221504a77d64bee785a3f53d7c3"
+    },
+    "org/apache/maven/resolver/maven-resolver-transport-file/1.6.3/maven-resolver-transport-file-1.6.3.jar": {
+      "sha256": "dceaf3d095d9aaee0f4abc5c9c05eac76ad82929d6cbbf610ab2350e61d04750"
+    },
+    "org/apache/maven/resolver/maven-resolver-transport-file/1.6.3/maven-resolver-transport-file-1.6.3.pom": {
+      "sha256": "af4b6f7e00311f524bfd9bbfebdb84761a3127602ddfa49077c786999243b151"
+    },
+    "org/apache/maven/resolver/maven-resolver-transport-http/1.6.3/maven-resolver-transport-http-1.6.3.jar": {
+      "sha256": "0a009a075f3cda76037585e2fdcf9d65e52d38f6d6be4382f1b5257c3a3b2f1b"
+    },
+    "org/apache/maven/resolver/maven-resolver-transport-http/1.6.3/maven-resolver-transport-http-1.6.3.pom": {
+      "sha256": "4ef353400ee0a0a102124f143827e6420defac77c0b81b75ad0f18d1bfad9adf"
+    },
+    "org/apache/maven/resolver/maven-resolver-util/1.6.3/maven-resolver-util-1.6.3.jar": {
+      "sha256": "cdcad9355b625743f40e4cead9a96353404e010c39c808d23b044be331afa251"
+    },
+    "org/apache/maven/resolver/maven-resolver-util/1.6.3/maven-resolver-util-1.6.3.pom": {
+      "sha256": "d1c35e76f4166f13b0a51d565acf967e9c3c79e2ccb69ccbf4fac098e4b7c466"
+    },
+    "org/apache/maven/resolver/maven-resolver/1.6.3/maven-resolver-1.6.3.pom": {
+      "sha256": "97397ee75b130ee2bb4a28e0fbb1259595a8361338aba082f8af147398e8a3ec"
+    },
+    "org/apache/maven/shared/maven-shared-components/34/maven-shared-components-34.pom": {
+      "sha256": "64d0edb5f21cfff600b1c3ab7d45f9754cd18ba5fbf83b3d1bb7c4849437d8e3"
+    },
+    "org/apache/maven/shared/maven-shared-utils/3.3.4/maven-shared-utils-3.3.4.jar": {
+      "sha256": "7925d9c5a0e2040d24b8fae3f612eb399cbffe5838b33ba368777dc7bddf6dda"
+    },
+    "org/apache/maven/shared/maven-shared-utils/3.3.4/maven-shared-utils-3.3.4.pom": {
+      "sha256": "bf83482d96f76d63699d63e125e64f4ac73c8178985733662dbd69af9c60339e"
+    },
+    "org/checkerframework/checker-compat-qual/2.5.5/checker-compat-qual-2.5.5.jar": {
+      "sha256": "11d134b245e9cacc474514d2d66b5b8618f8039a1465cdc55bbc0b34e0008b7a"
+    },
+    "org/checkerframework/checker-compat-qual/2.5.5/checker-compat-qual-2.5.5.pom": {
+      "sha256": "42f21ebd9183be049ee5afc822b345403a5da764037875734a039b0d6e0353be"
+    },
+    "org/checkerframework/checker-qual/3.12.0/checker-qual-3.12.0.jar": {
+      "sha256": "ff10785ac2a357ec5de9c293cb982a2cbb605c0309ea4cc1cb9b9bc6dbe7f3cb"
+    },
+    "org/checkerframework/checker-qual/3.12.0/checker-qual-3.12.0.pom": {
+      "sha256": "775b7ae36e62820b3b86dc1aa39af37c0ac4b85ff48f7fe485a922a2790f46b9"
+    },
+    "org/clojure/clojure/1.10.3/clojure-1.10.3.jar": {
+      "sha256": "7f12472daed8f6b517498aaa2ab13a562475c3edf51478e4581cc761e98979a3"
+    },
+    "org/clojure/clojure/1.10.3/clojure-1.10.3.pom": {
+      "sha256": "189c00c433407496a2fbb0eccb37908c94955d91ead1be48156744ecc1816d94"
+    },
+    "org/clojure/clojure/1.12.0/clojure-1.12.0.jar": {
+      "sha256": "c45333006441a059ea9fdb1341fc6c1f40b921a10dccd82665311e48a0384763"
+    },
+    "org/clojure/clojure/1.12.0/clojure-1.12.0.pom": {
+      "sha256": "29f462aa89cb97645758418a5f08d4c1a82b735c96e7af49817d16aa9b908150"
+    },
+    "org/clojure/core.async/1.5.644/core.async-1.5.644.jar": {
+      "sha256": "c7890901420932ab0233d99695a53c3d5f9eee2f2d4fbb7d85076c52cc45f447"
+    },
+    "org/clojure/core.async/1.5.644/core.async-1.5.644.pom": {
+      "sha256": "dedf42a27f933934695ab13c425223b1d53765ade5e5e2c060080bc0bf4224ca"
+    },
+    "org/clojure/core.cache/1.0.225/core.cache-1.0.225.jar": {
+      "sha256": "c153aa947eda5cdbd8a93882c8fbabd5037d4ad7311802b4bcd8015469f6a5b1"
+    },
+    "org/clojure/core.cache/1.0.225/core.cache-1.0.225.pom": {
+      "sha256": "39e341f67bfef393e478390d4988f119a779ca449066cb0d33f80b42ff04f43d"
+    },
+    "org/clojure/core.memoize/1.0.253/core.memoize-1.0.253.jar": {
+      "sha256": "4a910585182ab326c1d0a20d34315be1563b5a58437d41c021dd7fe9911e1ed6"
+    },
+    "org/clojure/core.memoize/1.0.253/core.memoize-1.0.253.pom": {
+      "sha256": "84c2fab7a32ca3c1e40c41a6ecc9bd536e947b30580e77b8d5dc232a34925eac"
+    },
+    "org/clojure/core.specs.alpha/0.2.56/core.specs.alpha-0.2.56.jar": {
+      "sha256": "fcf442bde02b04a863f2fcc58ee6a2a30c4cf0c970f7dab85634f0ab711166b6"
+    },
+    "org/clojure/core.specs.alpha/0.2.56/core.specs.alpha-0.2.56.pom": {
+      "sha256": "01aaf17483ff1c7482c92a07295d7e7bc6e3b3322df44b29b5738d020ff00740"
+    },
+    "org/clojure/core.specs.alpha/0.4.74/core.specs.alpha-0.4.74.jar": {
+      "sha256": "eb73ac08cf49ba840c88ba67beef11336ca554333d9408808d78946e0feb9ddb"
+    },
+    "org/clojure/core.specs.alpha/0.4.74/core.specs.alpha-0.4.74.pom": {
+      "sha256": "33410eb8aa73d52d957b3dc6e0a65f3998ac0623cbd813d90c33e6e689c42429"
+    },
+    "org/clojure/data.codec/0.1.0/data.codec-0.1.0.jar": {
+      "sha256": "683d681950403c61c236354181eba1b5c8daf6c13581ea1389934a7d5eb28e07"
+    },
+    "org/clojure/data.codec/0.1.0/data.codec-0.1.0.pom": {
+      "sha256": "f13d996846d6d7a702436265aa38632a674692025a418a56695c502813ddda78"
+    },
+    "org/clojure/data.csv/1.0.0/data.csv-1.0.0.jar": {
+      "sha256": "92170a3ca50b6c8d90322ddeaf462fcb3c83cd42dec96db85f2173c502765190"
+    },
+    "org/clojure/data.csv/1.0.0/data.csv-1.0.0.pom": {
+      "sha256": "25a3978a8f654b6042eeca8afaac48f4d796117add2ed1008bd271b442e6288f"
+    },
+    "org/clojure/data.json/2.4.0/data.json-2.4.0.jar": {
+      "sha256": "ec3f2f994e1eedd420313c452ba5518c5f5c97be5152dfed5650bc6611486adf"
+    },
+    "org/clojure/data.json/2.4.0/data.json-2.4.0.pom": {
+      "sha256": "a42ea70f17b517666ad8492a1bfa917de5defac7b47c516f6d0d4d89c2780cf4"
+    },
+    "org/clojure/data.priority-map/1.1.0/data.priority-map-1.1.0.jar": {
+      "sha256": "fe51af4472fa0f1bfd66f3871de55076402ff6615a74bcb17b37c402a0ea6f4c"
+    },
+    "org/clojure/data.priority-map/1.1.0/data.priority-map-1.1.0.pom": {
+      "sha256": "465200f94f56d8868e0fd7aa0becc62ffb02cfaf420a49ad117910e63af5dffe"
+    },
+    "org/clojure/data.xml/0.2.0-alpha6/data.xml-0.2.0-alpha6.jar": {
+      "sha256": "90882b4ac6f610e5fd711f885545a4909023b63d8e7d595918d97d181b59a828"
+    },
+    "org/clojure/data.xml/0.2.0-alpha6/data.xml-0.2.0-alpha6.pom": {
+      "sha256": "1f8880b9eb2484686c9eca3c306845d8db91e76a4d1c5f6457554edecca76336"
+    },
+    "org/clojure/java.classpath/1.0.0/java.classpath-1.0.0.jar": {
+      "sha256": "c14e0e10304a5e5cfd2cc742fbdefac1f5293eec6070c2ffe8903fb5c7fe7d6f"
+    },
+    "org/clojure/java.classpath/1.0.0/java.classpath-1.0.0.pom": {
+      "sha256": "0be013851457fc24c434ce45534643f226e5c10800486253fd373f2e09545e28"
+    },
+    "org/clojure/pom.contrib/0.0.25/pom.contrib-0.0.25.pom": {
+      "sha256": "ebc7b376e56d83f6c484cdb1d371efdc0130ddbbcade7d6da6e354f4e426fc8b"
+    },
+    "org/clojure/pom.contrib/0.2.2/pom.contrib-0.2.2.pom": {
+      "sha256": "e0ea227c49c5c3e30754cd26fcc57be7e4de973fe43aa5cc6667401ec5c10323"
+    },
+    "org/clojure/pom.contrib/0.3.0/pom.contrib-0.3.0.pom": {
+      "sha256": "7f182b3b2a543e057460bf93ffc5e9cef6ac527df1a1376a7d9922ebe79ef119"
+    },
+    "org/clojure/pom.contrib/1.0.0/pom.contrib-1.0.0.pom": {
+      "sha256": "1011faae5c9e496858e4c650ba33713abd469a5d52e00aeb7f5b01a2bcaf47e9"
+    },
+    "org/clojure/pom.contrib/1.1.0/pom.contrib-1.1.0.pom": {
+      "sha256": "10ece4bb5f9829010dc16561f42ebb83baf2f47605b51f9105b92f3caa089715"
+    },
+    "org/clojure/pom.contrib/1.2.0/pom.contrib-1.2.0.pom": {
+      "sha256": "0916d7a41558b9500a427c886fa29827ace5259206be3ad33e64e296fc1a6111"
+    },
+    "org/clojure/spec.alpha/0.2.194/spec.alpha-0.2.194.jar": {
+      "sha256": "cf6899f985298c64b13ea129946ad9028dee8dadf0eab9ae18e455027d38249c"
+    },
+    "org/clojure/spec.alpha/0.2.194/spec.alpha-0.2.194.pom": {
+      "sha256": "5a11f0e1e8b3c052e651c498c6945b44db3535bf2c18719fdcf65df1f88b13e6"
+    },
+    "org/clojure/spec.alpha/0.5.238/spec.alpha-0.5.238.jar": {
+      "sha256": "94cd99b6ea639641f37af4860a643b6ed399ee5a8be5d717cff0b663c8d75077"
+    },
+    "org/clojure/spec.alpha/0.5.238/spec.alpha-0.5.238.pom": {
+      "sha256": "3cba7e0dcc085c4ce92dddffea226124ffac178be79bd0379b5b2e30a969cbea"
+    },
+    "org/clojure/tools.analyzer.jvm/1.2.1/tools.analyzer.jvm-1.2.1.jar": {
+      "sha256": "f07259864b8d0dc5935ba840c737aedb35fd9b0db630d544f9fa278184635927"
+    },
+    "org/clojure/tools.analyzer.jvm/1.2.1/tools.analyzer.jvm-1.2.1.pom": {
+      "sha256": "ba7218cc0eb4e1595f2676587819c6aa0bd07c287644d8d995fa13d3c3d74c03"
+    },
+    "org/clojure/tools.analyzer/1.1.0/tools.analyzer-1.1.0.jar": {
+      "sha256": "1368b6bc3bddf7c398d5784d10548f44c4ed2d7c01ea105ac0efde9cf5e0df21"
+    },
+    "org/clojure/tools.analyzer/1.1.0/tools.analyzer-1.1.0.pom": {
+      "sha256": "3720712fb92761a35c94d0ee415d6bf15841ef469f073646776875e79dc9b706"
+    },
+    "org/clojure/tools.cli/1.0.206/tools.cli-1.0.206.jar": {
+      "sha256": "6b97d2691919b9ea944a898fec798a90ecb81a17732916edbc73a6f5afd1f616"
+    },
+    "org/clojure/tools.cli/1.0.206/tools.cli-1.0.206.pom": {
+      "sha256": "fd00cd0b8ab5c9f7c16958b056502dbaf72a47a4cb886e8002b5b0dbbb38f49e"
+    },
+    "org/clojure/tools.deps.alpha/0.12.1148/tools.deps.alpha-0.12.1148.jar": {
+      "sha256": "3b375c0b50aee4a8373dae2d1ef985fa439d19c05db51a954bfedb2627e703ff"
+    },
+    "org/clojure/tools.deps.alpha/0.12.1148/tools.deps.alpha-0.12.1148.pom": {
+      "sha256": "652d0ac8ffc76b5089bd04cb90c44d16c4d687ece70f3018e5a92fc07e0a0431"
+    },
+    "org/clojure/tools.gitlibs/2.4.172/tools.gitlibs-2.4.172.jar": {
+      "sha256": "f8bc385c7bba1b2e0122e7f3c454a1c9161f639370d34bb4b2afe9e80f7e0890"
+    },
+    "org/clojure/tools.gitlibs/2.4.172/tools.gitlibs-2.4.172.pom": {
+      "sha256": "6323060c1d0b1748a06b05df3e8f23b033232586be814c296556e8f76434ab8f"
+    },
+    "org/clojure/tools.logging/1.2.1/tools.logging-1.2.1.jar": {
+      "sha256": "ca9999416e3cc5b72034936c8bcc599f2a86850ebb9ceb4316a4a2687f315b6b"
+    },
+    "org/clojure/tools.logging/1.2.1/tools.logging-1.2.1.pom": {
+      "sha256": "260e76be75e7d06312530cc8bf3f74b0e34a2cb9dc3de231ff0e6712ffb7a378"
+    },
+    "org/clojure/tools.namespace/1.2.0/tools.namespace-1.2.0.jar": {
+      "sha256": "bc9ac99051089473943d5b3d3087d09d2d365adae06440671e5fb8a0061bd7e9"
+    },
+    "org/clojure/tools.namespace/1.2.0/tools.namespace-1.2.0.pom": {
+      "sha256": "b525e067c837f438fde000d78afaca1ded85d00c0d479d287aa9f4a1ae36b5ba"
+    },
+    "org/clojure/tools.reader/1.3.6/tools.reader-1.3.6.jar": {
+      "sha256": "11d1b31f2c65c3355b292bb9b44b8fcafda54b44da63e34ab97b79a8ab3bb8e0"
+    },
+    "org/clojure/tools.reader/1.3.6/tools.reader-1.3.6.pom": {
+      "sha256": "aef5ee828b7cb14a1c58f45b9f8a10ff340c5769925ea0ef5c35d1e49d920bea"
+    },
+    "org/codehaus/plexus/plexus-cipher/2.0/plexus-cipher-2.0.jar": {
+      "sha256": "9a7f1b5c5a9effd61eadfd8731452a2f76a8e79111fac391ef75ea801bea203a"
+    },
+    "org/codehaus/plexus/plexus-cipher/2.0/plexus-cipher-2.0.pom": {
+      "sha256": "04842f331b0225b85a5e20439710d228ea7a6302abe6d53c9c9846fbc5bf99ff"
+    },
+    "org/codehaus/plexus/plexus-classworlds/2.6.0/plexus-classworlds-2.6.0.jar": {
+      "sha256": "52f77c5ec49f787c9c417ebed5d6efd9922f44a202f217376e4f94c0d74f3549"
+    },
+    "org/codehaus/plexus/plexus-classworlds/2.6.0/plexus-classworlds-2.6.0.pom": {
+      "sha256": "469a6c59f92effa62c0797ce7d52d2c03cf8ee1034b923c360dd78a9f505a7ba"
+    },
+    "org/codehaus/plexus/plexus-component-annotations/2.1.0/plexus-component-annotations-2.1.0.jar": {
+      "sha256": "bde3617ce9b5bcf9584126046080043af6a4b3baea40a3b153f02e7bbc32acac"
+    },
+    "org/codehaus/plexus/plexus-component-annotations/2.1.0/plexus-component-annotations-2.1.0.pom": {
+      "sha256": "0670b605255f7dc9a454daaec7912918ccf1b5475cbfca374363b51fcfd4ea00"
+    },
+    "org/codehaus/plexus/plexus-containers/2.1.0/plexus-containers-2.1.0.pom": {
+      "sha256": "94d5aedb3c46023265396527cf8ce7fc944b7bd79e4ebab907386418eb5a08d7"
+    },
+    "org/codehaus/plexus/plexus-interpolation/1.26/plexus-interpolation-1.26.jar": {
+      "sha256": "b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662"
+    },
+    "org/codehaus/plexus/plexus-interpolation/1.26/plexus-interpolation-1.26.pom": {
+      "sha256": "e1c10b3a6335641eb74a668daa9ee86ae4ab06610174e59ba07c8c68042327f7"
+    },
+    "org/codehaus/plexus/plexus-sec-dispatcher/2.0/plexus-sec-dispatcher-2.0.jar": {
+      "sha256": "873139960c4c780176dda580b003a2c4bf82188bdce5bb99234e224ef7acfceb"
+    },
+    "org/codehaus/plexus/plexus-sec-dispatcher/2.0/plexus-sec-dispatcher-2.0.pom": {
+      "sha256": "9b28bb307017938a94d06c85b2b099bc46912b859d084fb293e569f432eadb7c"
+    },
+    "org/codehaus/plexus/plexus-utils/3.3.0/plexus-utils-3.3.0.pom": {
+      "sha256": "79c9792073fdee3cdbebd61a76ba8c2dd11624a9f85d128bae56bda19e20475c"
+    },
+    "org/codehaus/plexus/plexus-utils/3.4.1/plexus-utils-3.4.1.jar": {
+      "sha256": "52d85e04b3918722af11d12855b4a8257df96a0e76c8f4e3852e6faa851f357b"
+    },
+    "org/codehaus/plexus/plexus-utils/3.4.1/plexus-utils-3.4.1.pom": {
+      "sha256": "b144cff9b1c6259fec4fee5bdfc0f360d69c23abd4ea6e544533a949b69e3582"
+    },
+    "org/codehaus/plexus/plexus/5.1/plexus-5.1.pom": {
+      "sha256": "a343e44ff5796aed0ea60be11454c935ce20ab1c5f164acc8da574482dcbc7e9"
+    },
+    "org/codehaus/plexus/plexus/8/plexus-8.pom": {
+      "sha256": "ffa349db04e7abf65885bdc5a2062f4197c0ff9d3f1f4e2aa5720b77233f742c"
+    },
+    "org/eclipse/jetty/jetty-client/9.4.44.v20210927/jetty-client-9.4.44.v20210927.jar": {
+      "sha256": "81c335a33fea19ab71470e2b89295161f98a773fd3dfba1f4c4f9a358608090d"
+    },
+    "org/eclipse/jetty/jetty-client/9.4.44.v20210927/jetty-client-9.4.44.v20210927.pom": {
+      "sha256": "1627338bbacba002b74047d273f1b3e252e177349a0e699cf39b0eb8e473a010"
+    },
+    "org/eclipse/jetty/jetty-http/9.4.44.v20210927/jetty-http-9.4.44.v20210927.jar": {
+      "sha256": "0a09fac4c0ea826f920cfe8d5beced61dcd8fec0eae99b88c7619609fa0dc403"
+    },
+    "org/eclipse/jetty/jetty-http/9.4.44.v20210927/jetty-http-9.4.44.v20210927.pom": {
+      "sha256": "ee853d5c360d9ad46a7694e95f0aeb6b10b2e407ea12c8c423a1bec4356f92ae"
+    },
+    "org/eclipse/jetty/jetty-io/9.4.44.v20210927/jetty-io-9.4.44.v20210927.jar": {
+      "sha256": "3c6f1105500921aa4f9687c3a1b5fd9eba4661a5f438aa089829c2ecc9726745"
+    },
+    "org/eclipse/jetty/jetty-io/9.4.44.v20210927/jetty-io-9.4.44.v20210927.pom": {
+      "sha256": "fca766c2c259b63c669e8e49bbbdfc0a84b4d554a276589065ae0c0db828e9ad"
+    },
+    "org/eclipse/jetty/jetty-project/9.4.44.v20210927/jetty-project-9.4.44.v20210927.pom": {
+      "sha256": "fc1f9083e29d415aeec979b6ebf1506e536c05bdbecb5f601a192ccc98e4a0ad"
+    },
+    "org/eclipse/jetty/jetty-util/9.4.44.v20210927/jetty-util-9.4.44.v20210927.jar": {
+      "sha256": "539179024520b614f62d5d83f25bea111f7b991c399e5f737fa6aa2750489079"
+    },
+    "org/eclipse/jetty/jetty-util/9.4.44.v20210927/jetty-util-9.4.44.v20210927.pom": {
+      "sha256": "36440e0d44cea802a45b704191d8c3b4d67c8c394c8a02ab78c571ef7a1cd2ba"
+    },
+    "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.5/org.eclipse.sisu.inject-0.3.5.jar": {
+      "sha256": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13"
+    },
+    "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.5/org.eclipse.sisu.inject-0.3.5.pom": {
+      "sha256": "c2976972b4242ffd8604716d8475f56755da0fa28618344ec4e5327810696d71"
+    },
+    "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.5/org.eclipse.sisu.plexus-0.3.5.jar": {
+      "sha256": "7e4c61096d70826f20f7a7d55c59a5528e7aa5ad247ee2dfe544e4dd25f6a784"
+    },
+    "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.5/org.eclipse.sisu.plexus-0.3.5.pom": {
+      "sha256": "786523c9d78258a74aa13447a1676c2172acfdf432165d7adae2b7876d2d83d3"
+    },
+    "org/eclipse/sisu/sisu-inject/0.3.5/sisu-inject-0.3.5.pom": {
+      "sha256": "5f32ecab9c8f6dff1f9e41b853e40d8f23a2508219154ef67cc00d4556f5f5dd"
+    },
+    "org/eclipse/sisu/sisu-plexus/0.3.5/sisu-plexus-0.3.5.pom": {
+      "sha256": "6eba0902efd899aec0d8d19ac3cbc53123cd41139fe0e1d29cc5c874a791b9de"
+    },
+    "org/junit/junit-bom/5.7.2/junit-bom-5.7.2.pom": {
+      "sha256": "cd14aaa869991f82021c585d570d31ff342bcba58bb44233b70193771b96487b"
+    },
+    "org/junit/junit-bom/5.8.1/junit-bom-5.8.1.pom": {
+      "sha256": "ef7dc47f8e4a16864f4779728e87ed78539819e4fb892768a9da6b8ef903f863"
+    },
+    "org/ow2/asm/asm-parent/5.2/asm-parent-5.2.pom": {
+      "sha256": "cbfacd5dd812db16dc910994007fe58d9402a25507f81a1c2218e15c2c1bedfa"
+    },
+    "org/ow2/asm/asm/5.2/asm-5.2.jar": {
+      "sha256": "3e5ea0d7da2c5155ef4f470d9092d42de34e3f53db6589c7c07d6721adf4ba3e"
+    },
+    "org/ow2/asm/asm/5.2/asm-5.2.pom": {
+      "sha256": "289f7fbbd7b0c576d5286e8adcf8d0735134d3915efea6436e2be35c11fcf050"
+    },
+    "org/ow2/ow2/1.3/ow2-1.3.pom": {
+      "sha256": "51215c67d2c068d8b7d2f6f80f51372a098075deccc448d4bdd7b987ba8328fb"
+    },
+    "org/slf4j/jcl-over-slf4j/1.7.30/jcl-over-slf4j-1.7.30.jar": {
+      "sha256": "71e9ee37b9e4eb7802a2acc5f41728a4cf3915e7483d798db3b4ff2ec8847c50"
+    },
+    "org/slf4j/jcl-over-slf4j/1.7.30/jcl-over-slf4j-1.7.30.pom": {
+      "sha256": "16736dd4e71e7097b758be1553506f19a541eeb7766dc36355adaed7a536b455"
+    },
+    "org/slf4j/slf4j-api/1.7.32/slf4j-api-1.7.32.jar": {
+      "sha256": "3624f8474c1af46d75f98bc097d7864a323c81b3808aa43689a6e1c601c027be"
+    },
+    "org/slf4j/slf4j-api/1.7.32/slf4j-api-1.7.32.pom": {
+      "sha256": "001cde5b3c6ba91070425cfe9f2e695e4aeb8bc290a2d4cd96531127ab244fe5"
+    },
+    "org/slf4j/slf4j-nop/1.7.32/slf4j-nop-1.7.32.jar": {
+      "sha256": "f2d20b60b2b87fc1ca904e0cd4520deeeebf8a9c5b723ae2493cc4219389d782"
+    },
+    "org/slf4j/slf4j-nop/1.7.32/slf4j-nop-1.7.32.pom": {
+      "sha256": "5c1bb97f392cf7bc9d04fd1488d69857797036708ddd7f99cb39f3ec7518d733"
+    },
+    "org/slf4j/slf4j-parent/1.7.30/slf4j-parent-1.7.30.pom": {
+      "sha256": "11647956e48a0c5bfb3ac33f6da7e83f341002b6857efd335a505b687be34b75"
+    },
+    "org/slf4j/slf4j-parent/1.7.32/slf4j-parent-1.7.32.pom": {
+      "sha256": "5ab349d0f4c7bc08ed0ef1f4d9386cb1940a2f4d6f152150e16dbbecc0b83c70"
+    },
+    "org/sonatype/oss/oss-parent/5/oss-parent-5.pom": {
+      "sha256": "1678d4120a585d8a630131aeec4c524d928398583b7eab616ee7d5a87f520d3d"
+    },
+    "org/sonatype/oss/oss-parent/7/oss-parent-7.pom": {
+      "sha256": "b51f8867c92b6a722499557fc3a1fdea77bdf9ef574722fe90ce436a29559454"
+    },
+    "org/sonatype/oss/oss-parent/9/oss-parent-9.pom": {
+      "sha256": "fb40265f982548212ff82e362e59732b2187ec6f0d80182885c14ef1f982827a"
+    }
   }
 }

--- a/example/flake.lock
+++ b/example/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690395402,
-        "narHash": "sha256-CgbSNEzZwputkS6HpZbBe8uaBTjttlpPNvDqJrw0Foc=",
+        "lastModified": 1743432905,
+        "narHash": "sha256-OxreQ5mm1cbFx9jrMafAQppr9MM3JxGJYUadj5wCdv0=",
         "owner": "bevuta",
         "repo": "clojure-nix-locker",
-        "rev": "e2b0e4b043197b8d63e39c37333054689427a997",
+        "rev": "a4cf9216979fb92087c480fd560d590da0e5e499",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709356872,
-        "narHash": "sha256-mvxCirJbtkP0cZ6ABdwcgTk0u3bgLoIoEFIoYBvD6+4=",
+        "lastModified": 1749619289,
+        "narHash": "sha256-qX6gXVjaCXXbcn6A9eSLUf8Fm07MgPGe5ir3++y2O1Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "458b097d81f90275b3fdf03796f0563844926708",
+        "rev": "f72be405a10668b8b00937b452f2145244103ebc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Note that this changes the format  `deps.lock.json` in a non-backwards compatible way. Probably fine because projects which use it will pin `clojure-nix-locker` to a version that matches the format anyway.