### PR TITLE
Stabilize maven-metadata.xml

### DIFF
--- a/createHome.nix
+++ b/createHome.nix
@@ -14,14 +14,14 @@ let
     else { maven = {}; git = {}; };
 
   fetchMaven = file: dep: {
-    name = if dep ? name
-           then "${builtins.dirOf file}/${dep.name}"
-           else file;
-    path = pkgs.fetchurl {
-      # Try to fetch this maven dependency from all given maven repositories
-      urls = map (repo: repo + file) mavenRepos;
-      inherit (dep) sha256;
-    };
+    name = file;
+    path = if dep ? content
+           then pkgs.writeText (builtins.baseNameOf file) dep.content
+           else pkgs.fetchurl {
+             # Try to fetch this maven dependency from all given maven repositories
+             urls = map (repo: repo + file) mavenRepos;
+             inherit (dep) sha256;
+           };
   };
 
   handleGit = path: { url, rev, sha256, common_dir, ... }: {

--- a/example/deps.edn
+++ b/example/deps.edn
@@ -1,6 +1,8 @@
 ; adapted from https://clojure.org/guides/tools_build#_setup
 {:paths ["src"] ;; project paths
- :deps {org.clojure/data.csv {:mvn/version "1.0.0"}} ;; project deps
+ :deps {org.clojure/data.csv {:mvn/version "1.0.0"}
+        ;; Requires maven-metadata.xml for its bcprov-jdk18on dependency
+        org.bouncycastle/bcutil-jdk18on {:mvn/version "1.81"}}
 
  :aliases
  {;; Run with clj -T:build function-in-build

--- a/example/deps.lock.json
+++ b/example/deps.lock.json
@@ -302,6 +302,21 @@
     "org/apache/maven/shared/maven-shared-utils/3.3.4/maven-shared-utils-3.3.4.pom": {
       "sha256": "bf83482d96f76d63699d63e125e64f4ac73c8178985733662dbd69af9c60339e"
     },
+    "org/bouncycastle/bcprov-jdk18on/1.81/bcprov-jdk18on-1.81.jar": {
+      "sha256": "249f396412b0c0ce67f25c8197da757b241b8be3ec4199386c00704a2457459b"
+    },
+    "org/bouncycastle/bcprov-jdk18on/1.81/bcprov-jdk18on-1.81.pom": {
+      "sha256": "203990122be0fdd34bf12d0b788c0655161386a8e858ba43f06e3709c2cc74cc"
+    },
+    "org/bouncycastle/bcprov-jdk18on/maven-metadata-central.xml": {
+      "content": "<?xml version='1.0' encoding='utf-8'?><metadata><groupId>org.bouncycastle</groupId><artifactId>bcprov-jdk18on</artifactId><versioning><versions><version>1.81</version></versions></versioning></metadata>"
+    },
+    "org/bouncycastle/bcutil-jdk18on/1.81/bcutil-jdk18on-1.81.jar": {
+      "sha256": "31a5fe3a7ba42e3457b83930f0ff8d679fb5b76eaadf2b51f5740c92a394bf52"
+    },
+    "org/bouncycastle/bcutil-jdk18on/1.81/bcutil-jdk18on-1.81.pom": {
+      "sha256": "6543ee9dd6c554e6fdbefc39cc74f4258f452d10b253a5d6cd78548bf9492dd4"
+    },
     "org/checkerframework/checker-compat-qual/2.5.5/checker-compat-qual-2.5.5.jar": {
       "sha256": "11d134b245e9cacc474514d2d66b5b8618f8039a1465cdc55bbc0b34e0008b7a"
     },

--- a/example/flake.lock
+++ b/example/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743432905,
-        "narHash": "sha256-OxreQ5mm1cbFx9jrMafAQppr9MM3JxGJYUadj5wCdv0=",
+        "lastModified": 1751366240,
+        "narHash": "sha256-Gqk/f8775U0gpJa8Fb1RGW1WtylKFnXJxnVScZF9pWQ=",
         "owner": "bevuta",
         "repo": "clojure-nix-locker",
-        "rev": "a4cf9216979fb92087c480fd560d590da0e5e499",
+        "rev": "c99db6452027c3704fe640449b05c31e69039e88",
         "type": "github"
       },
       "original": {

--- a/example/src/simple.clj
+++ b/example/src/simple.clj
@@ -1,7 +1,8 @@
 (ns simple
   (:require [clojure.data.csv :as csv])
+  (:import (org.bouncycastle.asn1 ASN1Absent))
   (:gen-class))
 
 (defn -main [& args]
   (println (csv/read-csv "h1,h2\nfoo,bar\nbaz,qux"))
-)
+  (println "Thankfully" (str ASN1Absent/INSTANCE)))


### PR DESCRIPTION
This is a follow-up to https://github.com/bevuta/clojure-nix-locker/pull/14 which turned out to not work reliably because maven-metadata.xml files may change over time as new versions of an artifact get released. Instead, we now transform maven-metadata.xml files into a form which makes it stable against server-side updates but still allows maven to resolve version range dependencies with it. This transformed version is inlined with the lockfile since it's usually very small and applying the transformation at locktime is cheaper (and easier) than doing it at use time.