### PR TITLE
Update to nixpkgs 25.11

### DIFF
--- a/createHome.nix
+++ b/createHome.nix
@@ -40,7 +40,7 @@ let
   gitWorktreeCache = gitWorkTrees: pkgs.linkFarm "git-worktree-cache" gitWorkTrees;
 
   # This corresponds to the ~/.gitlibs/_repos directory, containing git directories for the above worktrees
-  gitFakeRepoCache = pkgs.runCommandNoCC "git-fake-repo-cache" {}
+  gitFakeRepoCache = pkgs.runCommand "git-fake-repo-cache" {}
     # We don't actually need these, however clojure has a check for the existence of a
     # `config` file in these directories, so let's create empty ones
 
@@ -54,7 +54,7 @@ let
     "mkdir -p $out");
 
   # Provides a ~/.clojure directory which clojure will accept read-only
-  configDir = pkgs.runCommandNoCC "config-dir" {} ''
+  configDir = pkgs.runCommand "config-dir" {} ''
     mkdir -p $out/tools
     echo '{}' > $out/deps.edn
     echo '{}' > $out/tools/tools.edn

--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@ let
   es = lib.escapeShellArg;
 
   standaloneLocker = pkgs.writers.writePython3Bin "standalone-clojure-nix-locker" {
-    libraries = [ pkgs.python3Packages.gitpython ];
+    libraries = [ pkgs.python3Packages.gitpython or pkgs.python3Packages.GitPython ];
     flakeIgnore = [
       "E501" # We don't care about lines being too long
       "W504" # Allow line breaks after binary operators for multi-line conditionals

--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@ let
   es = lib.escapeShellArg;
 
   standaloneLocker = pkgs.writers.writePython3Bin "standalone-clojure-nix-locker" {
-    libraries = [ pkgs.python3Packages.GitPython ];
+    libraries = [ pkgs.python3Packages.gitpython ];
     flakeIgnore = [
       "E501" # We don't care about lines being too long
       "W504" # Allow line breaks after binary operators for multi-line conditionals

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -17,15 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661772043,
-        "narHash": "sha256-J02+gLWJXFYKnA5XRPd/5M+Lj6ayfbxSG/yYh0ghHxE=",
+        "lastModified": 1765762245,
+        "narHash": "sha256-3iXM/zTqEskWtmZs3gqNiVtRTsEjYAedIaLL0mSBsrk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0c1c5b34f9604237450a2ece38c2e9168fa088b3",
+        "rev": "c8cfcd6ccd422e41cc631a0b73ed4d5a925c393d",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -34,6 +38,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Build clojure projects with nix by creating a lockfile for maven and git dependencies";
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/utils.nix
+++ b/utils.nix
@@ -21,7 +21,7 @@ rec {
       '')
       paths;
     in
-      pkgs.runCommandNoCC name { buildInputs = [ pkgs.makeWrapper ]; } ''
+      pkgs.runCommand name { buildInputs = [ pkgs.makeWrapper ]; } ''
           mkdir -p $out/bin
           ${script}
         '';


### PR DESCRIPTION
clojure-nix-locker no longer works with nixpkgs 25.11 due to `GitPython` being renamed to `gitpython`. This PR changes the name to match so that it'll work again.

The second commit renames `runCommandNoCC` to `runCommand` because the former issues a deprecation warning. According to [Noogle](https://noogle.dev/f/pkgs/runCommand) this command is literally an alias for the other now, so it should be safe, even though I have no idea what "NoCC" is supposed to do.